### PR TITLE
Fix search schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.1",
+        "@modelcontextprotocol/sdk": "^1.18.0",
         "@pinecone-database/pinecone": "^5.1.1",
         "zod": "^3.24.3"
       },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.1.tgz",
-      "integrity": "sha512-8q6+9aF0yA39/qWT/uaIj6zTpC+Qu07DnN/lb9mjoquCJsAh6l3HyYqc9O3t2j7GilseOQOQimLg7W3By6jqvg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.0.tgz",
+      "integrity": "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -33,6 +33,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.13.1",
+    "@modelcontextprotocol/sdk": "^1.18.0",
     "@pinecone-database/pinecone": "^5.1.1",
     "zod": "^3.24.3"
   },

--- a/src/tools/database/common/search-query.ts
+++ b/src/tools/database/common/search-query.ts
@@ -1,4 +1,4 @@
-import {z} from 'zod';
+import { z } from 'zod';
 
 export const SEARCH_QUERY_SCHEMA = z
   .object({
@@ -7,7 +7,8 @@ export const SEARCH_QUERY_SCHEMA = z
       text: z.string().describe('The text to search for.'),
     }),
     filter: z
-      .any()
+      .object({})
+      .passthrough()
       .optional()
       .describe(
         `A filter can be used to narrow down results. Use the syntax of


### PR DESCRIPTION
### Overview

User got the following error when using this server via Gemini CLI:
```
> gemini
Skipping tool 'search-records' from MCP server 'pinecone-dev-mcp-local' because it has missing types in its parameter schema. Please file an issue with the owner of the MCP server.
Skipping tool 'cascading-search' from MCP server 'pinecone-dev-mcp-local' because it has missing types in its parameter schema. Please file an issue with the owner of the MCP server.
```

### Link to issue

> Include a link to any issue addressed by this PR.

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Infrastructure change
- [ ] Documentation
