### PR TITLE
Add missing await to pc.inference.rerank call

### DIFF
--- a/src/tools/database/rerank-documents.ts
+++ b/src/tools/database/rerank-documents.ts
@@ -47,7 +47,7 @@ export function addRerankDocumentsTool(server: McpServer, pc: Pinecone) {
     INSTRUCTIONS,
     SCHEMA,
     async ({model, query, documents, options}) => {
-      const results = pc.inference.rerank(model, query, documents, options);
+      const results = await pc.inference.rerank(model, query, documents, options);
       return {
         content: [{type: 'text', text: JSON.stringify(results, null, 2)}],
       };


### PR DESCRIPTION
## Summary
- Add missing `await` to the `pc.inference.rerank()` call in `rerank-documents` tool
- Without this, the tool was returning `{}` because it serialized the Promise instead of the result

## Test plan
- [ ] Run `scripts/repro_empty_result.py` and verify it returns actual rerank results

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)