### PR TITLE
fix: make setup action use passed node_version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org
         cache: npm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node_version: '24.x'
+          git_email: 'clients@pinecone.io'
+          git_username: ${{ github.actor }}
 
       ##### VERSION BUMP #####
       - name: 'Bump version for production release'
@@ -83,12 +85,6 @@ jobs:
           echo "version=$newVersion" >> $GITHUB_OUTPUT
 
       ##### COMMIT AND TAG VERSION CHANGES (prod) #####
-      - name: Configure git CLI
-        if: github.event.inputs.releaseMode == 'prod'
-        shell: bash
-        run: |
-          git config --global user.email "clients@pinecone.io"
-          git config --global user.name "${{ github.actor }}"
       - name: Commit and tag version changes for prod
         if: github.event.inputs.releaseMode == 'prod'
         shell: bash


### PR DESCRIPTION
## Overview

Fixes the setup action to properly use the `node_version` input parameter instead of hardcoding Node.js 20.x, and consolidates git configuration into the setup action.

### Changes

- **Fixed setup action**: Changed `node-version` from hardcoded `20.x` to use the `${{ inputs.node_version }}` parameter, allowing the action to respect the version passed by workflows
- **Consolidated git configuration**: Moved git user configuration from the release workflow into the setup action, eliminating duplication and ensuring consistent git setup across all workflows that use the action
- **Updated release workflow**: Removed redundant "Configure git CLI" step and passed git configuration parameters to the setup action instead

### Type

- [x] Bug fix