### PR TITLE
fix: restore missing await in rerank-documents

### DIFF
--- a/src/tools/database/rerank-documents.ts
+++ b/src/tools/database/rerank-documents.ts
@@ -48,7 +48,7 @@ export function addRerankDocumentsTool(server: McpServer, pc: Pinecone) {
     SCHEMA,
     async ({model, query, documents, options}) => {
       try {
-        const results = pc.inference.rerank(model, query, documents, options);
+        const results = await pc.inference.rerank(model, query, documents, options);
         return {
           content: [{type: 'text', text: JSON.stringify(results, null, 2)}],
         };


### PR DESCRIPTION
## Summary
Restores the missing `await` in `rerank-documents.ts` that was accidentally dropped during conflict resolution in PR #16.

Without this fix, the tool returns a serialized Promise (`{}`) instead of actual rerank results.

## Changes
- Add `await` before `pc.inference.rerank()` call

## Test plan
- [ ] Verify rerank-documents tool returns actual results, not `{}`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes async handling in `rerank-documents` tool so it returns real rerank results instead of a serialized Promise.
> 
> - Adds `await` to `pc.inference.rerank(...)` in `src/tools/database/rerank-documents.ts`
> - Ensures tool response contains actual rerank output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d43acec8fa472920db49bb6a50b695aef2e4d31f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->