### PR TITLE
test: add integration tests for MCP tool handlers

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Mock the tool modules to track registration
+vi.mock('./tools/docs/index.js', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./tools/database/index.js', () => ({
+  default: vi.fn(),
+}));
+
+describe('setupServer', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns an McpServer instance', async () => {
+    const {default: setupServer} = await import('./server.js');
+    const server = await setupServer();
+
+    expect(server).toBeInstanceOf(McpServer);
+  });
+
+  it('configures server with correct name and version', async () => {
+    const {default: setupServer} = await import('./server.js');
+    const server = await setupServer();
+
+    // The server should have the correct configuration
+    // We can check this by inspecting the server's internal state
+    expect(server).toBeDefined();
+  });
+
+  it('registers docs tools', async () => {
+    const {default: addDocsTools} = await import('./tools/docs/index.js');
+    const {default: setupServer} = await import('./server.js');
+
+    await setupServer();
+
+    expect(addDocsTools).toHaveBeenCalled();
+  });
+
+  it('registers database tools', async () => {
+    const {default: addDatabaseTools} = await import('./tools/database/index.js');
+    const {default: setupServer} = await import('./server.js');
+
+    await setupServer();
+
+    expect(addDatabaseTools).toHaveBeenCalled();
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -27,15 +27,6 @@ describe('setupServer', () => {
     expect(server).toBeInstanceOf(McpServer);
   });
 
-  it('configures server with correct name and version', async () => {
-    const {default: setupServer} = await import('./server.js');
-    const server = await setupServer();
-
-    // The server should have the correct configuration
-    // We can check this by inspecting the server's internal state
-    expect(server).toBeDefined();
-  });
-
   it('registers docs tools', async () => {
     const {default: addDocsTools} = await import('./tools/docs/index.js');
     const {default: setupServer} = await import('./server.js');

--- a/src/test-utils/mock-pinecone.ts
+++ b/src/test-utils/mock-pinecone.ts
@@ -1,0 +1,35 @@
+import {vi} from 'vitest';
+
+export function createMockNamespace() {
+  return {
+    searchRecords: vi.fn(),
+    upsertRecords: vi.fn(),
+  };
+}
+
+export function createMockIndex() {
+  const mockNamespace = createMockNamespace();
+  return {
+    describeIndexStats: vi.fn(),
+    namespace: vi.fn(() => mockNamespace),
+    _mockNamespace: mockNamespace,
+  };
+}
+
+export function createMockPinecone() {
+  const mockIndex = createMockIndex();
+  return {
+    listIndexes: vi.fn(),
+    describeIndex: vi.fn(),
+    createIndexForModel: vi.fn(),
+    index: vi.fn(() => mockIndex),
+    inference: {
+      rerank: vi.fn(),
+    },
+    _mockIndex: mockIndex,
+  };
+}
+
+export type MockPinecone = ReturnType<typeof createMockPinecone>;
+export type MockIndex = ReturnType<typeof createMockIndex>;
+export type MockNamespace = ReturnType<typeof createMockNamespace>;

--- a/src/test-utils/mock-server.ts
+++ b/src/test-utils/mock-server.ts
@@ -1,0 +1,30 @@
+import {vi} from 'vitest';
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<unknown>;
+
+interface RegisteredTool {
+  instructions: string;
+  schema: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+export function createMockServer() {
+  const tools = new Map<string, RegisteredTool>();
+
+  return {
+    tool: vi.fn(
+      (
+        name: string,
+        instructions: string,
+        schema: Record<string, unknown>,
+        handler: ToolHandler,
+      ) => {
+        tools.set(name, {instructions, schema, handler});
+      },
+    ),
+    getRegisteredTool: (name: string) => tools.get(name),
+    getRegisteredToolNames: () => Array.from(tools.keys()),
+  };
+}
+
+export type MockServer = ReturnType<typeof createMockServer>;

--- a/src/tools/database/cascading-search.test.ts
+++ b/src/tools/database/cascading-search.test.ts
@@ -1,0 +1,147 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addCascadingSearchTool} from './cascading-search.js';
+
+describe('cascading-search tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addCascadingSearchTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'cascading-search',
+      expect.any(String),
+      expect.objectContaining({
+        indexes: expect.anything(),
+        query: expect.anything(),
+        rerank: expect.anything(),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('searches across multiple indexes and reranks results', async () => {
+    const mockSearchResults1 = {
+      result: {
+        hits: [
+          {_id: 'rec-1', fields: {content: 'Hello from index 1'}},
+          {_id: 'rec-2', fields: {content: 'World from index 1'}},
+        ],
+      },
+    };
+    const mockSearchResults2 = {
+      result: {
+        hits: [{_id: 'rec-3', fields: {content: 'Hi from index 2'}}],
+      },
+    };
+    const mockRerankedResults = {
+      data: [{index: 0, score: 0.95, document: {content: 'Hello from index 1'}}],
+    };
+
+    mockPc._mockIndex._mockNamespace.searchRecords
+      .mockResolvedValueOnce(mockSearchResults1)
+      .mockResolvedValueOnce(mockSearchResults2);
+    mockPc.inference.rerank.mockResolvedValue(mockRerankedResults);
+
+    addCascadingSearchTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('cascading-search');
+    const result = await tool!.handler({
+      indexes: [
+        {name: 'index-1', namespace: 'ns-1'},
+        {name: 'index-2', namespace: 'ns-2'},
+      ],
+      query: {inputs: {text: 'hello'}, topK: 10},
+      rerank: {
+        model: 'bge-reranker-v2-m3',
+        topN: 5,
+        rankFields: ['content'],
+      },
+    });
+
+    expect(mockPc._mockIndex._mockNamespace.searchRecords).toHaveBeenCalledTimes(2);
+    expect(mockPc.inference.rerank).toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(mockRerankedResults, null, 2)}],
+    });
+  });
+
+  it('deduplicates results by _id', async () => {
+    const mockSearchResults1 = {
+      result: {
+        hits: [{_id: 'rec-1', fields: {content: 'Hello'}}],
+      },
+    };
+    const mockSearchResults2 = {
+      result: {
+        hits: [{_id: 'rec-1', fields: {content: 'Hello duplicate'}}],
+      },
+    };
+
+    mockPc._mockIndex._mockNamespace.searchRecords
+      .mockResolvedValueOnce(mockSearchResults1)
+      .mockResolvedValueOnce(mockSearchResults2);
+    mockPc.inference.rerank.mockResolvedValue({data: []});
+
+    addCascadingSearchTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('cascading-search');
+    await tool!.handler({
+      indexes: [
+        {name: 'index-1', namespace: 'ns-1'},
+        {name: 'index-2', namespace: 'ns-2'},
+      ],
+      query: {inputs: {text: 'hello'}, topK: 10},
+      rerank: {model: 'bge-reranker-v2-m3', rankFields: ['content']},
+    });
+
+    // Should only have one document (deduplicated)
+    expect(mockPc.inference.rerank).toHaveBeenCalledWith(
+      'bge-reranker-v2-m3',
+      'hello',
+      [{content: 'Hello'}], // Only the first occurrence
+      expect.any(Object),
+    );
+  });
+
+  it('handles empty results without calling rerank', async () => {
+    mockPc._mockIndex._mockNamespace.searchRecords.mockResolvedValue({
+      result: {hits: []},
+    });
+
+    addCascadingSearchTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('cascading-search');
+    const result = await tool!.handler({
+      indexes: [{name: 'index-1', namespace: 'ns-1'}],
+      query: {inputs: {text: 'hello'}, topK: 10},
+      rerank: {model: 'bge-reranker-v2-m3', rankFields: ['content']},
+    });
+
+    expect(mockPc.inference.rerank).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify([], null, 2)}],
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc._mockIndex._mockNamespace.searchRecords.mockRejectedValue(new Error('Search failed'));
+
+    addCascadingSearchTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('cascading-search');
+    const result = await tool!.handler({
+      indexes: [{name: 'index-1', namespace: 'ns-1'}],
+      query: {inputs: {text: 'hello'}, topK: 10},
+      rerank: {model: 'bge-reranker-v2-m3', rankFields: ['content']},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: Search failed'}],
+    });
+  });
+});

--- a/src/tools/database/create-index-for-model.test.ts
+++ b/src/tools/database/create-index-for-model.test.ts
@@ -1,0 +1,109 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addCreateIndexForModelTool} from './create-index-for-model.js';
+
+describe('create-index-for-model tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addCreateIndexForModelTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'create-index-for-model',
+      expect.any(String),
+      expect.objectContaining({name: expect.anything(), embed: expect.anything()}),
+      expect.any(Function),
+    );
+  });
+
+  it('creates index when it does not exist', async () => {
+    mockPc.listIndexes.mockResolvedValue({indexes: []});
+    const mockNewIndex = {
+      name: 'new-index',
+      dimension: 1024,
+      metric: 'cosine',
+    };
+    mockPc.createIndexForModel.mockResolvedValue(mockNewIndex);
+
+    addCreateIndexForModelTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('create-index-for-model');
+    const result = await tool!.handler({
+      name: 'new-index',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+    });
+
+    expect(mockPc.listIndexes).toHaveBeenCalled();
+    expect(mockPc.createIndexForModel).toHaveBeenCalledWith({
+      name: 'new-index',
+      cloud: 'aws',
+      region: 'us-east-1',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+      tags: {
+        source: 'mcp',
+        embedding_model: 'multilingual-e5-large',
+      },
+      waitUntilReady: true,
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(mockNewIndex, null, 2)}],
+    });
+  });
+
+  it('returns message when index already exists', async () => {
+    const existingIndex = {name: 'existing-index', dimension: 768};
+    mockPc.listIndexes.mockResolvedValue({indexes: [existingIndex]});
+
+    addCreateIndexForModelTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('create-index-for-model');
+    const result = await tool!.handler({
+      name: 'existing-index',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+    });
+
+    expect(mockPc.createIndexForModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('Index not created'),
+        },
+      ],
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc.listIndexes.mockResolvedValue({indexes: []});
+    mockPc.createIndexForModel.mockRejectedValue(new Error('API error'));
+
+    addCreateIndexForModelTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('create-index-for-model');
+    const result = await tool!.handler({
+      name: 'new-index',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: API error'}],
+    });
+  });
+});

--- a/src/tools/database/describe-index-stats.test.ts
+++ b/src/tools/database/describe-index-stats.test.ts
@@ -1,0 +1,68 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addDescribeIndexStatsTool} from './describe-index-stats.js';
+
+describe('describe-index-stats tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'describe-index-stats',
+      expect.any(String),
+      expect.objectContaining({name: expect.anything()}),
+      expect.any(Function),
+    );
+  });
+
+  it('returns index stats on success', async () => {
+    const mockStats = {
+      namespaces: {
+        '': {recordCount: 100},
+        'namespace-1': {recordCount: 50},
+      },
+      dimension: 1536,
+      indexFullness: 0.5,
+      totalRecordCount: 150,
+    };
+    mockPc._mockIndex.describeIndexStats.mockResolvedValue(mockStats);
+
+    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('describe-index-stats');
+    const result = await tool!.handler({name: 'test-index'});
+
+    expect(mockPc.index).toHaveBeenCalledWith('test-index');
+    expect(mockPc._mockIndex.describeIndexStats).toHaveBeenCalled();
+
+    // indexFullness should be excluded from the response
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({...mockStats, indexFullness: undefined}, null, 2),
+        },
+      ],
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc._mockIndex.describeIndexStats.mockRejectedValue(new Error('API error'));
+
+    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('describe-index-stats');
+    const result = await tool!.handler({name: 'test-index'});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: API error'}],
+    });
+  });
+});

--- a/src/tools/database/describe-index.test.ts
+++ b/src/tools/database/describe-index.test.ts
@@ -1,0 +1,63 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addDescribeIndexTool} from './describe-index.js';
+
+describe('describe-index tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addDescribeIndexTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'describe-index',
+      expect.any(String),
+      expect.objectContaining({name: expect.anything()}),
+      expect.any(Function),
+    );
+  });
+
+  it('returns index info on success', async () => {
+    const mockIndexInfo = {
+      name: 'test-index',
+      dimension: 1536,
+      metric: 'cosine',
+      host: 'test-index.svc.pinecone.io',
+      status: {ready: true},
+    };
+    mockPc.describeIndex.mockResolvedValue(mockIndexInfo);
+
+    addDescribeIndexTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('describe-index');
+    const result = await tool!.handler({name: 'test-index'});
+
+    expect(mockPc.describeIndex).toHaveBeenCalledWith('test-index');
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(mockIndexInfo, null, 2),
+        },
+      ],
+    });
+  });
+
+  it('returns error response when index not found', async () => {
+    mockPc.describeIndex.mockRejectedValue(new Error('Index not found'));
+
+    addDescribeIndexTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('describe-index');
+    const result = await tool!.handler({name: 'nonexistent'});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: Index not found'}],
+    });
+  });
+});

--- a/src/tools/database/index.test.ts
+++ b/src/tools/database/index.test.ts
@@ -1,0 +1,78 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+
+// Mock the Pinecone client
+vi.mock('@pinecone-database/pinecone', () => ({
+  Pinecone: vi.fn().mockImplementation(() => ({
+    listIndexes: vi.fn(),
+    describeIndex: vi.fn(),
+    createIndexForModel: vi.fn(),
+    index: vi.fn(() => ({
+      describeIndexStats: vi.fn(),
+      namespace: vi.fn(() => ({
+        searchRecords: vi.fn(),
+        upsertRecords: vi.fn(),
+      })),
+    })),
+    inference: {rerank: vi.fn()},
+  })),
+}));
+
+describe('addDatabaseTools', () => {
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockServer = createMockServer();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('registers all database tools when API key is set', async () => {
+    vi.stubEnv('PINECONE_API_KEY', 'test-api-key');
+
+    const {default: addDatabaseTools} = await import('./index.js');
+    addDatabaseTools(mockServer as never);
+
+    const registeredTools = mockServer.getRegisteredToolNames();
+    expect(registeredTools).toContain('list-indexes');
+    expect(registeredTools).toContain('describe-index');
+    expect(registeredTools).toContain('describe-index-stats');
+    expect(registeredTools).toContain('create-index-for-model');
+    expect(registeredTools).toContain('upsert-records');
+    expect(registeredTools).toContain('search-records');
+    expect(registeredTools).toContain('rerank-documents');
+    expect(registeredTools).toContain('cascading-search');
+    expect(registeredTools.length).toBe(8);
+  });
+
+  it('skips registration when API key is not set', async () => {
+    vi.stubEnv('PINECONE_API_KEY', '');
+
+    const {default: addDatabaseTools} = await import('./index.js');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    addDatabaseTools(mockServer as never);
+
+    expect(mockServer.getRegisteredToolNames().length).toBe(0);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('PINECONE_API_KEY'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('creates Pinecone client with correct source tag', async () => {
+    vi.stubEnv('PINECONE_API_KEY', 'test-api-key');
+
+    const {Pinecone} = await import('@pinecone-database/pinecone');
+    const {default: addDatabaseTools} = await import('./index.js');
+
+    addDatabaseTools(mockServer as never);
+
+    expect(Pinecone).toHaveBeenCalledWith({
+      apiKey: 'test-api-key',
+      sourceTag: expect.stringMatching(/^pinecone-mcp@/),
+    });
+  });
+});

--- a/src/tools/database/list-indexes.test.ts
+++ b/src/tools/database/list-indexes.test.ts
@@ -1,0 +1,79 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addListIndexesTool} from './list-indexes.js';
+
+describe('list-indexes tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addListIndexesTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'list-indexes',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns formatted index list on success', async () => {
+    const mockIndexes = {
+      indexes: [
+        {name: 'test-index-1', dimension: 1536},
+        {name: 'test-index-2', dimension: 768},
+      ],
+    };
+    mockPc.listIndexes.mockResolvedValue(mockIndexes);
+
+    addListIndexesTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('list-indexes');
+    const result = await tool!.handler({});
+
+    expect(mockPc.listIndexes).toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(mockIndexes, null, 2),
+        },
+      ],
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc.listIndexes.mockRejectedValue(new Error('API error'));
+
+    addListIndexesTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('list-indexes');
+    const result = await tool!.handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: API error'}],
+    });
+  });
+
+  it('handles empty index list', async () => {
+    mockPc.listIndexes.mockResolvedValue({indexes: []});
+
+    addListIndexesTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('list-indexes');
+    const result = await tool!.handler({});
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({indexes: []}, null, 2),
+        },
+      ],
+    });
+  });
+});

--- a/src/tools/database/rerank-documents.test.ts
+++ b/src/tools/database/rerank-documents.test.ts
@@ -1,0 +1,101 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addRerankDocumentsTool} from './rerank-documents.js';
+
+describe('rerank-documents tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addRerankDocumentsTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'rerank-documents',
+      expect.any(String),
+      expect.objectContaining({
+        model: expect.anything(),
+        query: expect.anything(),
+        documents: expect.anything(),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('reranks string documents successfully', async () => {
+    const mockResults = {
+      data: [
+        {index: 0, score: 0.95, document: {text: 'Hello world'}},
+        {index: 1, score: 0.85, document: {text: 'Hi there'}},
+      ],
+    };
+    mockPc.inference.rerank.mockResolvedValue(mockResults);
+
+    addRerankDocumentsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('rerank-documents');
+    const documents = ['Hello world', 'Hi there', 'Goodbye'];
+    const result = await tool!.handler({
+      model: 'bge-reranker-v2-m3',
+      query: 'greeting',
+      documents,
+      options: {topN: 2},
+    });
+
+    expect(mockPc.inference.rerank).toHaveBeenCalledWith(
+      'bge-reranker-v2-m3',
+      'greeting',
+      documents,
+      {topN: 2},
+    );
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(mockResults, null, 2)}],
+    });
+  });
+
+  it('reranks record documents with rankFields', async () => {
+    const mockResults = {data: [{index: 0, score: 0.9}]};
+    mockPc.inference.rerank.mockResolvedValue(mockResults);
+
+    addRerankDocumentsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('rerank-documents');
+    const documents = [{content: 'Hello world'}, {content: 'Hi there'}];
+    await tool!.handler({
+      model: 'cohere-rerank-3.5',
+      query: 'greeting',
+      documents,
+      options: {topN: 1, rankFields: ['content']},
+    });
+
+    expect(mockPc.inference.rerank).toHaveBeenCalledWith(
+      'cohere-rerank-3.5',
+      'greeting',
+      documents,
+      {
+        topN: 1,
+        rankFields: ['content'],
+      },
+    );
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc.inference.rerank.mockRejectedValue(new Error('Rerank failed'));
+
+    addRerankDocumentsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('rerank-documents');
+    const result = await tool!.handler({
+      model: 'bge-reranker-v2-m3',
+      query: 'test',
+      documents: ['doc1', 'doc2'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: Rerank failed'}],
+    });
+  });
+});

--- a/src/tools/database/search-records.test.ts
+++ b/src/tools/database/search-records.test.ts
@@ -1,0 +1,102 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addSearchRecordsTool} from './search-records.js';
+
+describe('search-records tool', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addSearchRecordsTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'search-records',
+      expect.any(String),
+      expect.objectContaining({
+        name: expect.anything(),
+        namespace: expect.anything(),
+        query: expect.anything(),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('returns search results on success', async () => {
+    const mockResults = {
+      result: {
+        hits: [
+          {_id: 'rec-1', _score: 0.95, fields: {content: 'Hello'}},
+          {_id: 'rec-2', _score: 0.85, fields: {content: 'World'}},
+        ],
+      },
+    };
+    mockPc._mockIndex._mockNamespace.searchRecords.mockResolvedValue(mockResults);
+
+    addSearchRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('search-records');
+    const query = {inputs: {text: 'hello'}, topK: 10};
+    const result = await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      query,
+    });
+
+    expect(mockPc.index).toHaveBeenCalledWith('test-index');
+    expect(mockPc._mockIndex.namespace).toHaveBeenCalledWith('test-ns');
+    expect(mockPc._mockIndex._mockNamespace.searchRecords).toHaveBeenCalledWith({
+      query,
+      rerank: undefined,
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(mockResults, null, 2)}],
+    });
+  });
+
+  it('passes rerank options when provided', async () => {
+    const mockResults = {result: {hits: []}};
+    mockPc._mockIndex._mockNamespace.searchRecords.mockResolvedValue(mockResults);
+
+    addSearchRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('search-records');
+    const query = {inputs: {text: 'hello'}, topK: 10};
+    const rerank = {
+      model: 'bge-reranker-v2-m3',
+      topN: 5,
+      rankFields: ['content'],
+    };
+    await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      query,
+      rerank,
+    });
+
+    expect(mockPc._mockIndex._mockNamespace.searchRecords).toHaveBeenCalledWith({
+      query,
+      rerank,
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc._mockIndex._mockNamespace.searchRecords.mockRejectedValue(new Error('Search failed'));
+
+    addSearchRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('search-records');
+    const result = await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      query: {inputs: {text: 'hello'}, topK: 10},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: Search failed'}],
+    });
+  });
+});

--- a/src/tools/database/upsert-records.handler.test.ts
+++ b/src/tools/database/upsert-records.handler.test.ts
@@ -1,0 +1,87 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addUpsertRecordsTool} from './upsert-records.js';
+
+describe('upsert-records tool handler', () => {
+  let mockPc: MockPinecone;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockPc = createMockPinecone();
+    mockServer = createMockServer();
+  });
+
+  it('registers with the correct name', () => {
+    addUpsertRecordsTool(mockServer as never, mockPc as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'upsert-records',
+      expect.any(String),
+      expect.objectContaining({
+        name: expect.anything(),
+        namespace: expect.anything(),
+        records: expect.anything(),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('upserts records successfully', async () => {
+    mockPc._mockIndex._mockNamespace.upsertRecords.mockResolvedValue(undefined);
+
+    addUpsertRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('upsert-records');
+    const records = [
+      {id: 'rec-1', content: 'Hello world'},
+      {id: 'rec-2', content: 'Goodbye world'},
+    ];
+    const result = await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      records,
+    });
+
+    expect(mockPc.index).toHaveBeenCalledWith('test-index');
+    expect(mockPc._mockIndex.namespace).toHaveBeenCalledWith('test-ns');
+    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith(records);
+    expect(result).toEqual({
+      content: [{type: 'text', text: 'Data upserted successfully'}],
+    });
+  });
+
+  it('returns error response on API failure', async () => {
+    mockPc._mockIndex._mockNamespace.upsertRecords.mockRejectedValue(new Error('API error'));
+
+    addUpsertRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('upsert-records');
+    const result = await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      records: [{id: 'rec-1', content: 'Hello'}],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Error: API error'}],
+    });
+  });
+
+  it('handles records with _id field', async () => {
+    mockPc._mockIndex._mockNamespace.upsertRecords.mockResolvedValue(undefined);
+
+    addUpsertRecordsTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('upsert-records');
+    const records = [{_id: 'rec-1', content: 'Hello world'}];
+    const result = await tool!.handler({
+      name: 'test-index',
+      namespace: 'test-ns',
+      records,
+    });
+
+    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith(records);
+    expect(result).toEqual({
+      content: [{type: 'text', text: 'Data upserted successfully'}],
+    });
+  });
+});

--- a/src/tools/docs/search-docs.test.ts
+++ b/src/tools/docs/search-docs.test.ts
@@ -1,0 +1,47 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {addSearchDocsTool} from './search-docs.js';
+
+// Mock the MCP SDK client modules
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    callTool: vi.fn().mockResolvedValue({
+      content: [{type: 'text', text: 'Documentation result'}],
+    }),
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe('search-docs tool', () => {
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    vi.clearAllMocks();
+  });
+
+  it('registers with the correct name', () => {
+    addSearchDocsTool(mockServer as never);
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'search-docs',
+      expect.any(String),
+      expect.objectContaining({query: expect.anything()}),
+      expect.any(Function),
+    );
+  });
+
+  it('calls the docs MCP server and returns results', async () => {
+    addSearchDocsTool(mockServer as never);
+    const tool = mockServer.getRegisteredTool('search-docs');
+    const result = await tool!.handler({query: 'how to create index'});
+
+    expect(result).toEqual({
+      content: [{type: 'text', text: 'Documentation result'}],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for all MCP tool handlers, addressing SDK-72.

**Changes:**
- Created shared test utilities (`mock-pinecone.ts`, `mock-server.ts`) for consistent mocking
- Added handler tests for all 8 database tools with success/error scenarios
- Added tests for `search-docs` tool with mocked MCP client
- Added tests for `setupServer()` function and tool registration
- Test count increased from 28 to 68 tests (+40 new tests)

## Test Approach

The tests use a mock server pattern that captures registered tool handlers:

```typescript
const mockServer = createMockServer();
addListIndexesTool(mockServer, mockPc);

const tool = mockServer.getRegisteredTool('list-indexes');
const result = await tool.handler({});

expect(result.content[0].text).toContain('test-index');
```

Each tool is tested for:
- Correct registration with MCP server
- Success path returning proper MCP response format
- Error handling returning `isError: true` response

## Test Plan

- [x] All 68 tests pass locally
- [x] Build succeeds
- [x] Code formatted with Prettier

## Related

- Closes SDK-72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands automated coverage for MCP tool handlers with focused unit/integration-style tests and shared mocks.
> 
> - New Vitest suites for `setupServer()` registration, `search-docs`, and all database tools: `list-indexes`, `describe-index`, `describe-index-stats`, `create-index-for-model`, `upsert-records`, `search-records`, `rerank-documents`, `cascading-search`
> - Introduces reusable test utilities: `test-utils/mock-pinecone.ts` and `test-utils/mock-server.ts` to simulate Pinecone client and MCP server tool registration/handlers
> - Verifies success paths, error handling (`isError: true`), option passthrough (e.g., `rerank`/`rankFields`), deduplication in `cascading-search`, and environment-gated registration in `tools/database/index`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b24d88598e3dc64e469f0ccf360e63f0e7a40f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->