### PR TITLE
feat: allow configurable cloud and region for index creation

### DIFF
--- a/src/tools/database/create-index-for-model.test.ts
+++ b/src/tools/database/create-index-for-model.test.ts
@@ -28,7 +28,7 @@ describe('create-index-for-model tool', () => {
     );
   });
 
-  it('creates index with default cloud and region when not specified', async () => {
+  it('creates index with specified cloud and region', async () => {
     mockPc.listIndexes.mockResolvedValue({indexes: []});
     const mockNewIndex = {
       name: 'new-index',

--- a/src/tools/database/create-index-for-model.test.ts
+++ b/src/tools/database/create-index-for-model.test.ts
@@ -12,18 +12,23 @@ describe('create-index-for-model tool', () => {
     mockServer = createMockServer();
   });
 
-  it('registers with the correct name', () => {
+  it('registers with the correct name and schema', () => {
     addCreateIndexForModelTool(mockServer as never, mockPc as never);
 
     expect(mockServer.tool).toHaveBeenCalledWith(
       'create-index-for-model',
       expect.any(String),
-      expect.objectContaining({name: expect.anything(), embed: expect.anything()}),
+      expect.objectContaining({
+        name: expect.anything(),
+        cloud: expect.anything(),
+        region: expect.anything(),
+        embed: expect.anything(),
+      }),
       expect.any(Function),
     );
   });
 
-  it('creates index when it does not exist', async () => {
+  it('creates index with default cloud and region when not specified', async () => {
     mockPc.listIndexes.mockResolvedValue({indexes: []});
     const mockNewIndex = {
       name: 'new-index',
@@ -36,6 +41,8 @@ describe('create-index-for-model tool', () => {
     const tool = mockServer.getRegisteredTool('create-index-for-model');
     const result = await tool!.handler({
       name: 'new-index',
+      cloud: 'aws',
+      region: 'us-east-1',
       embed: {
         model: 'multilingual-e5-large',
         fieldMap: {text: 'content'},
@@ -62,6 +69,46 @@ describe('create-index-for-model tool', () => {
     });
   });
 
+  it('creates index with custom cloud and region', async () => {
+    mockPc.listIndexes.mockResolvedValue({indexes: []});
+    const mockNewIndex = {
+      name: 'gcp-index',
+      dimension: 1024,
+      metric: 'cosine',
+    };
+    mockPc.createIndexForModel.mockResolvedValue(mockNewIndex);
+
+    addCreateIndexForModelTool(mockServer as never, mockPc as never);
+    const tool = mockServer.getRegisteredTool('create-index-for-model');
+    const result = await tool!.handler({
+      name: 'gcp-index',
+      cloud: 'gcp',
+      region: 'us-central1',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+    });
+
+    expect(mockPc.createIndexForModel).toHaveBeenCalledWith({
+      name: 'gcp-index',
+      cloud: 'gcp',
+      region: 'us-central1',
+      embed: {
+        model: 'multilingual-e5-large',
+        fieldMap: {text: 'content'},
+      },
+      tags: {
+        source: 'mcp',
+        embedding_model: 'multilingual-e5-large',
+      },
+      waitUntilReady: true,
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(mockNewIndex, null, 2)}],
+    });
+  });
+
   it('returns message when index already exists', async () => {
     const existingIndex = {name: 'existing-index', dimension: 768};
     mockPc.listIndexes.mockResolvedValue({indexes: [existingIndex]});
@@ -70,6 +117,8 @@ describe('create-index-for-model tool', () => {
     const tool = mockServer.getRegisteredTool('create-index-for-model');
     const result = await tool!.handler({
       name: 'existing-index',
+      cloud: 'aws',
+      region: 'us-east-1',
       embed: {
         model: 'multilingual-e5-large',
         fieldMap: {text: 'content'},
@@ -95,6 +144,8 @@ describe('create-index-for-model tool', () => {
     const tool = mockServer.getRegisteredTool('create-index-for-model');
     const result = await tool!.handler({
       name: 'new-index',
+      cloud: 'aws',
+      region: 'us-east-1',
       embed: {
         model: 'multilingual-e5-large',
         fieldMap: {text: 'content'},


### PR DESCRIPTION
## Summary

- Adds optional `cloud` and `region` parameters to the `create-index-for-model` tool
- Enables users to create indexes in their preferred cloud provider and region
- Maintains backward compatibility with sensible defaults (aws, us-east-1)

## Changes

- **create-index-for-model.ts**: Added `cloud` (enum: aws/gcp/azure) and `region` (string) parameters with defaults
- **create-index-for-model.test.ts**: Added test for custom cloud/region, updated existing tests

## Usage

```typescript
// Default behavior (unchanged)
{
  name: "my-index",
  embed: { model: "multilingual-e5-large", fieldMap: { text: "content" } }
}

// Custom cloud and region
{
  name: "my-gcp-index",
  cloud: "gcp",
  region: "us-central1",
  embed: { model: "multilingual-e5-large", fieldMap: { text: "content" } }
}
```

## Test plan

- [x] Build succeeds
- [x] All 69 tests pass
- [x] New test verifies custom cloud/region are passed to API

Fixes SDK-78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables configuring cloud and region for Pinecone index creation while preserving default behavior.
> 
> - Extend `create-index-for-model` schema with optional `cloud` (aws/gcp/azure) and `region` (defaults `aws/us-east-1`)
> - Pass `cloud` and `region` through to `pc.createIndexForModel`; keep tags and `waitUntilReady: true`
> - Update tool instructions to mention supported providers; maintain existing index-existence check and error handling
> - Tests updated: registration asserts new schema fields; add cases for specified and custom cloud/region; adjust existing tests accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89a9764324bf8fd39bef9cdc35e1a31eb651c828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->