### PR TITLE
feat: add LLM caller tracking for usage analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@pinecone-database/pinecone": "^5.1.1",
+        "@pinecone-database/pinecone": "^6.1.4",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-5.1.2.tgz",
-      "integrity": "sha512-z7737KUA1hXwd508q1+o4bnRxj0NpMmzA2beyaFm7Y+EC2TYLT5ABuYsn/qhiwiEsYp8v1qS596eBhhvgNagig==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-6.1.4.tgz",
+      "integrity": "sha512-wkipvpkBYNGYDeYj4azVVyCzSrekJE3Pgo0HImkbw80SGnTo9gz5kSbDCXCfVvFnhqC2q4nGikdTUvFCDiuruA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
-    "@pinecone-database/pinecone": "^5.1.1",
+    "@pinecone-database/pinecone": "^6.1.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/tools/database/cascading-search.ts
+++ b/src/tools/database/cascading-search.ts
@@ -98,10 +98,15 @@ export function addCascadingSearchTool(server: McpServer) {
 
         const rerankedResults =
           deduplicatedResultsArray.length > 0
-            ? await pc.inference.rerank(rerank.model, rerank.query || query.inputs.text, deduplicatedResultsArray, {
-                topN: rerank.topN || query.topK,
-                rankFields: rerank.rankFields,
-              })
+            ? await pc.inference.rerank(
+                rerank.model,
+                rerank.query || query.inputs.text,
+                deduplicatedResultsArray,
+                {
+                  topN: rerank.topN || query.topK,
+                  rankFields: rerank.rankFields,
+                },
+              )
             : [];
 
         return {

--- a/src/tools/database/cascading-search.ts
+++ b/src/tools/database/cascading-search.ts
@@ -1,8 +1,15 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {Pinecone} from '@pinecone-database/pinecone';
 import {z} from 'zod';
 import {RERANK_MODEL_SCHEMA} from './common/rerank-model.js';
+import {registerDatabaseTool} from './common/register-tool.js';
 import {SEARCH_QUERY_SCHEMA} from './common/search-query.js';
+
+type RerankModelType = 'bge-reranker-v2-m3' | 'pinecone-rerank-v0' | 'cohere-rerank-3.5';
+type SearchQuery = {
+  inputs: {text: string};
+  topK: number;
+  filter?: Record<string, unknown>;
+};
 
 const INSTRUCTIONS = `Search across multiple indexes for records that are
 similar to the query text, deduplicate and rerank the results.`;
@@ -50,14 +57,29 @@ export const SCHEMA = {
   rerank: RERANK_SCHEMA,
 };
 
-export function addCascadingSearchTool(server: McpServer, pc: Pinecone) {
-  server.registerTool(
+type IndexSpec = {name: string; namespace: string};
+type RerankSpec = {
+  model: RerankModelType;
+  topN?: number;
+  rankFields: string[];
+  query?: string;
+};
+type CascadingSearchArgs = {
+  indexes: IndexSpec[];
+  query: SearchQuery;
+  rerank: RerankSpec;
+};
+
+export function addCascadingSearchTool(server: McpServer) {
+  registerDatabaseTool(
+    server,
     'cascading-search',
     {description: INSTRUCTIONS, inputSchema: SCHEMA},
-    async ({indexes, query, rerank}) => {
+    async (args, pc) => {
+      const {indexes, query, rerank} = args as CascadingSearchArgs;
       try {
         const initialResults = await Promise.all(
-          indexes.map(async (index: {name: string; namespace: string}) => {
+          indexes.map(async (index: IndexSpec) => {
             const ns = pc.index(index.name).namespace(index.namespace || '');
             const results = await ns.searchRecords({query});
             return results;
@@ -76,27 +98,22 @@ export function addCascadingSearchTool(server: McpServer, pc: Pinecone) {
 
         const rerankedResults =
           deduplicatedResultsArray.length > 0
-            ? await pc.inference.rerank(
-                rerank.model,
-                rerank.query || query.inputs.text,
-                deduplicatedResultsArray,
-                {
-                  topN: rerank.topN || query.topK,
-                  rankFields: rerank.rankFields,
-                },
-              )
+            ? await pc.inference.rerank(rerank.model, rerank.query || query.inputs.text, deduplicatedResultsArray, {
+                topN: rerank.topN || query.topK,
+                rankFields: rerank.rankFields,
+              })
             : [];
 
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(rerankedResults, null, 2),
             },
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text', text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
       }
     },
   );

--- a/src/tools/database/common/pinecone-client.ts
+++ b/src/tools/database/common/pinecone-client.ts
@@ -24,7 +24,15 @@ export function getPineconeClient(caller?: Caller): Pinecone {
   let client = clientCache.get(key);
   if (!client) {
     // Only include caller if model is provided (model is required by the SDK)
-    const callerConfig = caller?.model ? {caller: {provider: caller.provider, model: caller.model}} : {};
+    // Conditionally include provider only when it has a value to avoid {provider: undefined}
+    const callerConfig = caller?.model
+      ? {
+          caller: {
+            ...(caller.provider ? {provider: caller.provider} : {}),
+            model: caller.model,
+          },
+        }
+      : {};
 
     client = new Pinecone({
       apiKey: PINECONE_API_KEY,

--- a/src/tools/database/common/pinecone-client.ts
+++ b/src/tools/database/common/pinecone-client.ts
@@ -10,8 +10,9 @@ export type Caller = {
 const clientCache = new Map<string, Pinecone>();
 
 function getCacheKey(caller?: Caller): string {
-  if (!caller?.provider && !caller?.model) return 'default';
-  return `${caller.provider || ''}:${caller.model || ''}`;
+  // Only create unique cache keys when model is present, since caller config requires model
+  if (!caller?.model) return 'default';
+  return `${caller.provider || ''}:${caller.model}`;
 }
 
 export function getPineconeClient(caller?: Caller): Pinecone {

--- a/src/tools/database/common/pinecone-client.ts
+++ b/src/tools/database/common/pinecone-client.ts
@@ -1,0 +1,42 @@
+import {Pinecone} from '@pinecone-database/pinecone';
+import {PINECONE_API_KEY} from '../../../constants.js';
+import {PINECONE_MCP_VERSION} from '../../../version.js';
+
+export type Caller = {
+  provider?: string;
+  model?: string;
+};
+
+const clientCache = new Map<string, Pinecone>();
+
+function getCacheKey(caller?: Caller): string {
+  if (!caller?.provider && !caller?.model) return 'default';
+  return `${caller.provider || ''}:${caller.model || ''}`;
+}
+
+export function getPineconeClient(caller?: Caller): Pinecone {
+  if (!PINECONE_API_KEY) {
+    throw new Error('PINECONE_API_KEY environment variable is not set');
+  }
+
+  const key = getCacheKey(caller);
+
+  let client = clientCache.get(key);
+  if (!client) {
+    // Only include caller if model is provided (model is required by the SDK)
+    const callerConfig = caller?.model ? {caller: {provider: caller.provider, model: caller.model}} : {};
+
+    client = new Pinecone({
+      apiKey: PINECONE_API_KEY,
+      sourceTag: `pinecone-mcp@${PINECONE_MCP_VERSION}`,
+      ...callerConfig,
+    });
+    clientCache.set(key, client);
+  }
+  return client;
+}
+
+// For testing: clear the client cache
+export function clearClientCache(): void {
+  clientCache.clear();
+}

--- a/src/tools/database/common/register-tool.ts
+++ b/src/tools/database/common/register-tool.ts
@@ -29,8 +29,8 @@ export function registerDatabaseTool<T extends ZodRawShape>(
 ) {
   const mergedSchema = {...config.inputSchema, ...LLM_CALLER_SCHEMA};
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server.registerTool(name, {description: config.description, inputSchema: mergedSchema}, (async (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     allArgs: any,
   ) => {
     const {llm_provider, llm_model, ...toolArgs} = allArgs as Record<string, unknown> & {

--- a/src/tools/database/common/register-tool.ts
+++ b/src/tools/database/common/register-tool.ts
@@ -1,0 +1,37 @@
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {Pinecone} from '@pinecone-database/pinecone';
+import {z, ZodRawShape} from 'zod';
+import {getPineconeClient} from './pinecone-client.js';
+
+const LLM_CALLER_SCHEMA = {
+  llm_provider: z
+    .string()
+    .optional()
+    .describe('Optional: The LLM provider (e.g., "anthropic", "google", "openai")'),
+  llm_model: z
+    .string()
+    .optional()
+    .describe('Optional: The LLM model (e.g., "claude-sonnet-4-20250514", "gemini-2.0-flash")'),
+};
+
+type TextContent = {type: 'text'; text: string};
+type CallToolResult = {content: TextContent[]; isError?: boolean};
+
+export function registerDatabaseTool<T extends ZodRawShape>(
+  server: McpServer,
+  name: string,
+  config: {description: string; inputSchema: T},
+  handler: (args: Record<string, unknown>, pc: Pinecone) => Promise<CallToolResult>,
+) {
+  const mergedSchema = {...config.inputSchema, ...LLM_CALLER_SCHEMA};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.registerTool(name, {description: config.description, inputSchema: mergedSchema}, (async (allArgs: any) => {
+    const {llm_provider, llm_model, ...toolArgs} = allArgs as Record<string, unknown> & {
+      llm_provider?: string;
+      llm_model?: string;
+    };
+    const pc = getPineconeClient({provider: llm_provider, model: llm_model});
+    return handler(toolArgs, pc);
+  }) as never);
+}

--- a/src/tools/database/common/register-tool.ts
+++ b/src/tools/database/common/register-tool.ts
@@ -8,13 +8,13 @@ const LLM_CALLER_SCHEMA = {
     .string()
     .optional()
     .describe(
-      'Your provider name if you are an AI model (e.g., "anthropic", "openai", "google"). Used for usage analytics. Do not prompt the user for this.'
+      'Your provider name if you are an AI model (e.g., "anthropic", "openai", "google"). Used for usage analytics. Do not prompt the user for this.',
     ),
   llm_model: z
     .string()
     .optional()
     .describe(
-      'Your model name if you are an AI model (e.g., "claude-sonnet-4-20250514", "gpt-4o"). Used for usage analytics. Do not prompt the user for this.'
+      'Your model name if you are an AI model (e.g., "claude-sonnet-4-20250514", "gpt-4o"). Used for usage analytics. Do not prompt the user for this.',
     ),
 };
 
@@ -30,7 +30,9 @@ export function registerDatabaseTool<T extends ZodRawShape>(
   const mergedSchema = {...config.inputSchema, ...LLM_CALLER_SCHEMA};
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server.registerTool(name, {description: config.description, inputSchema: mergedSchema}, (async (allArgs: any) => {
+  server.registerTool(name, {description: config.description, inputSchema: mergedSchema}, (async (
+    allArgs: any,
+  ) => {
     const {llm_provider, llm_model, ...toolArgs} = allArgs as Record<string, unknown> & {
       llm_provider?: string;
       llm_model?: string;

--- a/src/tools/database/common/register-tool.ts
+++ b/src/tools/database/common/register-tool.ts
@@ -7,11 +7,15 @@ const LLM_CALLER_SCHEMA = {
   llm_provider: z
     .string()
     .optional()
-    .describe('Optional: The LLM provider (e.g., "anthropic", "google", "openai")'),
+    .describe(
+      'Your provider name if you are an AI model (e.g., "anthropic", "openai", "google"). Used for usage analytics. Do not prompt the user for this.'
+    ),
   llm_model: z
     .string()
     .optional()
-    .describe('Optional: The LLM model (e.g., "claude-sonnet-4-20250514", "gemini-2.0-flash")'),
+    .describe(
+      'Your model name if you are an AI model (e.g., "claude-sonnet-4-20250514", "gpt-4o"). Used for usage analytics. Do not prompt the user for this.'
+    ),
 };
 
 type TextContent = {type: 'text'; text: string};

--- a/src/tools/database/describe-index-stats.test.ts
+++ b/src/tools/database/describe-index-stats.test.ts
@@ -1,6 +1,13 @@
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
 import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+
+// Mock the pinecone-client module
+vi.mock('./common/pinecone-client.js', () => ({
+  getPineconeClient: vi.fn(),
+}));
+
+import {getPineconeClient} from './common/pinecone-client.js';
 import {addDescribeIndexStatsTool} from './describe-index-stats.js';
 
 describe('describe-index-stats tool', () => {
@@ -10,16 +17,17 @@ describe('describe-index-stats tool', () => {
   beforeEach(() => {
     mockPc = createMockPinecone();
     mockServer = createMockServer();
+    vi.mocked(getPineconeClient).mockReturnValue(mockPc as never);
   });
 
   it('registers with the correct name', () => {
-    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+    addDescribeIndexStatsTool(mockServer as never);
 
     expect(mockServer.registerTool).toHaveBeenCalledWith(
       'describe-index-stats',
       expect.objectContaining({
         description: expect.any(String),
-        inputSchema: expect.objectContaining({name: expect.anything()}),
+        inputSchema: expect.any(Object),
       }),
       expect.any(Function),
     );
@@ -29,22 +37,18 @@ describe('describe-index-stats tool', () => {
     const mockStats = {
       namespaces: {
         '': {recordCount: 100},
-        'namespace-1': {recordCount: 50},
+        ns1: {recordCount: 50},
       },
       dimension: 1536,
-      indexFullness: 0.5,
       totalRecordCount: 150,
     };
     mockPc._mockIndex.describeIndexStats.mockResolvedValue(mockStats);
 
-    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+    addDescribeIndexStatsTool(mockServer as never);
     const tool = mockServer.getRegisteredTool('describe-index-stats');
     const result = await tool!.handler({name: 'test-index'});
 
     expect(mockPc.index).toHaveBeenCalledWith('test-index');
-    expect(mockPc._mockIndex.describeIndexStats).toHaveBeenCalled();
-
-    // indexFullness should be excluded from the response
     expect(result).toEqual({
       content: [
         {
@@ -58,7 +62,7 @@ describe('describe-index-stats tool', () => {
   it('returns error response on API failure', async () => {
     mockPc._mockIndex.describeIndexStats.mockRejectedValue(new Error('API error'));
 
-    addDescribeIndexStatsTool(mockServer as never, mockPc as never);
+    addDescribeIndexStatsTool(mockServer as never);
     const tool = mockServer.getRegisteredTool('describe-index-stats');
     const result = await tool!.handler({name: 'test-index'});
 

--- a/src/tools/database/describe-index-stats.ts
+++ b/src/tools/database/describe-index-stats.ts
@@ -1,6 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {Pinecone} from '@pinecone-database/pinecone';
 import {z} from 'zod';
+import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Describe the statistics of a Pinecone index and its namespaces';
 
@@ -8,24 +8,26 @@ const SCHEMA = {
   name: z.string().describe('The index to describe.'),
 };
 
-export function addDescribeIndexStatsTool(server: McpServer, pc: Pinecone) {
-  server.registerTool(
+export function addDescribeIndexStatsTool(server: McpServer) {
+  registerDatabaseTool(
+    server,
     'describe-index-stats',
     {description: INSTRUCTIONS, inputSchema: SCHEMA},
-    async ({name}) => {
+    async (args, pc) => {
+      const {name} = args as {name: string};
       try {
         const index = pc.index(name);
         const indexStats = await index.describeIndexStats();
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify({...indexStats, indexFullness: undefined}, null, 2),
             },
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text', text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
       }
     },
   );

--- a/src/tools/database/describe-index.ts
+++ b/src/tools/database/describe-index.ts
@@ -1,6 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {Pinecone} from '@pinecone-database/pinecone';
 import {z} from 'zod';
+import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Describe the configuration of a Pinecone index';
 
@@ -8,23 +8,25 @@ const SCHEMA = {
   name: z.string().describe('The index to describe.'),
 };
 
-export function addDescribeIndexTool(server: McpServer, pc: Pinecone) {
-  server.registerTool(
+export function addDescribeIndexTool(server: McpServer) {
+  registerDatabaseTool(
+    server,
     'describe-index',
     {description: INSTRUCTIONS, inputSchema: SCHEMA},
-    async ({name}) => {
+    async (args, pc) => {
+      const {name} = args as {name: string};
       try {
         const indexInfo = await pc.describeIndex(name);
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(indexInfo, null, 2),
             },
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text', text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
       }
     },
   );

--- a/src/tools/database/index.ts
+++ b/src/tools/database/index.ts
@@ -1,7 +1,5 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {Pinecone} from '@pinecone-database/pinecone';
 import {PINECONE_API_KEY} from '../../constants.js';
-import {PINECONE_MCP_VERSION} from '../../version.js';
 import {addCascadingSearchTool} from './cascading-search.js';
 import {addCreateIndexForModelTool} from './create-index-for-model.js';
 import {addDescribeIndexStatsTool} from './describe-index-stats.js';
@@ -17,17 +15,12 @@ export default function addDatabaseTools(server: McpServer) {
     return;
   }
 
-  const pc = new Pinecone({
-    apiKey: PINECONE_API_KEY,
-    sourceTag: `pinecone-mcp@${PINECONE_MCP_VERSION}`,
-  });
-
-  addListIndexesTool(server, pc);
-  addDescribeIndexTool(server, pc);
-  addDescribeIndexStatsTool(server, pc);
-  addCreateIndexForModelTool(server, pc);
-  addUpsertRecordsTool(server, pc);
-  addSearchRecordsTool(server, pc);
-  addRerankDocumentsTool(server, pc);
-  addCascadingSearchTool(server, pc);
+  addListIndexesTool(server);
+  addDescribeIndexTool(server);
+  addDescribeIndexStatsTool(server);
+  addCreateIndexForModelTool(server);
+  addUpsertRecordsTool(server);
+  addSearchRecordsTool(server);
+  addRerankDocumentsTool(server);
+  addCascadingSearchTool(server);
 }

--- a/src/tools/database/list-indexes.ts
+++ b/src/tools/database/list-indexes.ts
@@ -4,19 +4,24 @@ import {registerDatabaseTool} from './common/register-tool.js';
 const INSTRUCTIONS = `List all Pinecone indexes`;
 
 export function addListIndexesTool(server: McpServer) {
-  registerDatabaseTool(server, 'list-indexes', {description: INSTRUCTIONS, inputSchema: {}}, async (_, pc) => {
-    try {
-      const indexes = await pc.listIndexes();
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(indexes, null, 2),
-          },
-        ],
-      };
-    } catch (e) {
-      return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
-    }
-  });
+  registerDatabaseTool(
+    server,
+    'list-indexes',
+    {description: INSTRUCTIONS, inputSchema: {}},
+    async (_, pc) => {
+      try {
+        const indexes = await pc.listIndexes();
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(indexes, null, 2),
+            },
+          ],
+        };
+      } catch (e) {
+        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+      }
+    },
+  );
 }

--- a/src/tools/database/list-indexes.ts
+++ b/src/tools/database/list-indexes.ts
@@ -1,22 +1,22 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {Pinecone} from '@pinecone-database/pinecone';
+import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = `List all Pinecone indexes`;
 
-export function addListIndexesTool(server: McpServer, pc: Pinecone) {
-  server.registerTool('list-indexes', {description: INSTRUCTIONS, inputSchema: {}}, async () => {
+export function addListIndexesTool(server: McpServer) {
+  registerDatabaseTool(server, 'list-indexes', {description: INSTRUCTIONS, inputSchema: {}}, async (_, pc) => {
     try {
       const indexes = await pc.listIndexes();
       return {
         content: [
           {
-            type: 'text',
+            type: 'text' as const,
             text: JSON.stringify(indexes, null, 2),
           },
         ],
       };
     } catch (e) {
-      return {isError: true, content: [{type: 'text', text: String(e)}]};
+      return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
     }
   });
 }

--- a/src/tools/database/upsert-records.handler.test.ts
+++ b/src/tools/database/upsert-records.handler.test.ts
@@ -46,7 +46,9 @@ describe('upsert-records tool handler', () => {
 
     expect(mockPc.index).toHaveBeenCalledWith('test-index');
     expect(mockPc._mockIndex.namespace).toHaveBeenCalledWith('test-ns');
-    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith([{id: '1', content: 'test content'}]);
+    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith([
+      {id: '1', content: 'test content'},
+    ]);
     expect(result).toEqual({
       content: [{type: 'text', text: 'Data upserted successfully'}],
     });


### PR DESCRIPTION
## Summary

This PR enables LLM caller tracking by upgrading the Pinecone SDK to v6.1.4 and adding optional `llm_provider` and `llm_model` parameters to all database tools.

**Problem:** We have limited visibility into which AI providers and models are using the MCP server, making it difficult to understand usage patterns and prioritize development efforts.

**Solution:** Allow LLMs to self-identify when calling tools. When provided, these values are passed to the Pinecone SDK's `caller` configuration, which includes them in request `User-Agent` headers for analytics.

### Architecture

- **Centralized wrapper pattern:** A new `registerDatabaseTool` helper automatically injects the caller schema fields (`llm_provider`, `llm_model`) into all tool schemas
- **Client caching:** A `getPineconeClient` factory caches Pinecone clients by caller signature to avoid creating duplicate clients
- **Minimal per-tool changes:** Tools receive the Pinecone client as a parameter in their handler, keeping the changes isolated

### Key Changes

- Upgrade `@pinecone-database/pinecone` from `^5.1.1` to `^6.1.4`
- New files:
  - `src/tools/database/common/pinecone-client.ts` - Client factory with caching
  - `src/tools/database/common/register-tool.ts` - Centralized registration wrapper
- Updated all 8 database tools to use the new pattern

### Usage Example

```json
{
  "name": "search-records",
  "arguments": {
    "name": "my-index",
    "namespace": "default", 
    "query": {"inputs": {"text": "hello world"}, "topK": 10},
    "llm_provider": "anthropic",
    "llm_model": "claude-sonnet-4-20250514"
  }
}
```

The caller parameters are optional - tools work normally if they're not provided.

## Test Plan

- [x] All 69 existing tests pass
- [x] New test verifies that all tools include `llm_provider` and `llm_model` in their schemas
- [x] Build succeeds
- [x] Lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces LLM caller analytics and simplifies tool wiring while upgrading the Pinecone SDK.
> 
> - **Upgrade** `@pinecone-database/pinecone` to `^6.1.4`
> - **New** `registerDatabaseTool` wrapper injects `llm_provider`/`llm_model` into all tool schemas and passes a Pinecone client to handlers
> - **New** `common/pinecone-client.ts` factory with per-caller client caching and `sourceTag`/`caller` configuration
> - **Refactor** all database tools (`list-indexes`, `describe-index*`, `create-index-for-model`, `upsert-records`, `search-records`, `rerank-documents`, `cascading-search`) to use the wrapper and no longer construct the client directly
> - **Update** tests to mock `getPineconeClient`, assert caller fields in schemas, and align expectations with new behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d82472578aee32192a19e2b1cc1ff00c98d93e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->