### PR TITLE
feat: improve package.json metadata and TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This MCP server is focused on improving the experience of developers working wit
 
 To configure the MCP server to access your Pinecone project, you will need to generate an API key using the [console](https://app.pinecone.io). Without an API key, your AI tool will still be able to search documentation. However, it will not be able to manage or query your indexes.
 
-The MCP server requires [Node.js](https://nodejs.org). Ensure that `node` and `npx` are available in your `PATH`.
+The MCP server requires [Node.js](https://nodejs.org) v18 or later. Ensure that `node` and `npx` are available in your `PATH`.
 
 Next, you will need to configure your AI assistant to use the MCP server.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "@pinecone-database/mcp",
   "version": "0.1.17",
+  "description": "Model Context Protocol server for Pinecone - enables AI assistants to interact with Pinecone indexes and documentation",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "pinecone-mcp": "dist/index.js"
   },
@@ -23,7 +31,8 @@
     "lint:fix": "eslint src/ --fix",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
@@ -39,5 +48,19 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.53.1",
     "vitest": "^3.2.4"
+  },
+  "keywords": [
+    "mcp",
+    "pinecone",
+    "vector-database",
+    "ai",
+    "model-context-protocol"
+  ],
+  "homepage": "https://docs.pinecone.io/guides/operations/mcp-server",
+  "bugs": {
+    "url": "https://github.com/pinecone-io/pinecone-mcp/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.17",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "pinecone-mcp": "dist/index.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "declaration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
## Summary

This PR consolidates multiple package.json improvements into a single change:

- **SDK-87**: Add types field and enable TypeScript declaration generation
- **SDK-88**: Add prepublishOnly script to ensure build runs before npm publish
- **SDK-89**: Add description field for npm discoverability
- **SDK-90**: Add engines field specifying Node.js >=18 requirement
- **SDK-91**: Add exports field for modern ESM compatibility with bundlers
- **SDK-93**: Add keywords, homepage, and bugs fields for npm metadata

## Changes

### package.json
- Added description field
- Added types field pointing to dist/index.d.ts
- Added exports field with proper ESM entry points
- Added prepublishOnly script
- Added keywords array for npm search
- Added homepage and bugs URLs
- Added engines field requiring Node.js 18+

### tsconfig.json
- Enabled declaration: true to generate .d.ts files

### README.md
- Updated to mention Node.js v18+ requirement

## Test Plan

- [x] Build succeeds (npm run build)
- [x] All 69 tests pass (npm test)
- [x] Declaration file dist/index.d.ts is generated
- [x] Formatter passes (npm run format)

Resolves: SDK-87, SDK-88, SDK-89, SDK-90, SDK-91, SDK-93