### PR TITLE
refactor: improve error message formatting in tool handlers

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,70 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+
+// Mock the server module
+const mockServer = {
+  connect: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('./server.js', () => ({
+  default: vi.fn().mockResolvedValue(mockServer),
+}));
+
+// Mock the stdio transport
+const mockTransport = {mockTransport: true};
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: vi.fn().mockImplementation(() => mockTransport),
+}));
+
+describe('index (main entry point)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let consoleErrorSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let processExitSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  it('sets up server and connects transport on successful start', async () => {
+    const {default: setupServer} = await import('./server.js');
+    const {StdioServerTransport} = await import('@modelcontextprotocol/sdk/server/stdio.js');
+
+    // Import the module to trigger main()
+    await import('./index.js');
+
+    // Wait for async operations
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(setupServer).toHaveBeenCalled();
+    expect(StdioServerTransport).toHaveBeenCalled();
+    expect(mockServer.connect).toHaveBeenCalledWith(mockTransport);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Pinecone MCP Server running on stdio');
+  });
+
+  it('logs error and exits with code 1 on failure', async () => {
+    const testError = new Error('Test connection failure');
+
+    // Reset and re-mock with failing server
+    vi.resetModules();
+    vi.doMock('./server.js', () => ({
+      default: vi.fn().mockRejectedValue(testError),
+    }));
+
+    // Re-import to get fresh mocks
+    await import('./index.js');
+
+    // Wait for async operations
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Fatal error in main():', testError);
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/tools/database/cascading-search.test.ts
+++ b/src/tools/database/cascading-search.test.ts
@@ -148,7 +148,7 @@ describe('cascading-search tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: Search failed'}],
+      content: [{type: 'text', text: 'Search failed'}],
     });
   });
 });

--- a/src/tools/database/cascading-search.ts
+++ b/src/tools/database/cascading-search.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {RERANK_MODEL_SCHEMA} from './common/rerank-model.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 import {SEARCH_QUERY_SCHEMA} from './common/search-query.js';
@@ -118,7 +119,7 @@ export function addCascadingSearchTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/common/format-error.test.ts
+++ b/src/tools/database/common/format-error.test.ts
@@ -1,0 +1,34 @@
+import {describe, it, expect} from 'vitest';
+import {formatError} from './format-error.js';
+
+describe('formatError', () => {
+  it('extracts message from Error instances', () => {
+    const error = new Error('Something went wrong');
+    expect(formatError(error)).toBe('Something went wrong');
+  });
+
+  it('extracts message from Error subclasses', () => {
+    const error = new TypeError('Invalid type');
+    expect(formatError(error)).toBe('Invalid type');
+  });
+
+  it('converts string values directly', () => {
+    expect(formatError('plain string error')).toBe('plain string error');
+  });
+
+  it('converts number values to string', () => {
+    expect(formatError(404)).toBe('404');
+  });
+
+  it('converts null to string', () => {
+    expect(formatError(null)).toBe('null');
+  });
+
+  it('converts undefined to string', () => {
+    expect(formatError(undefined)).toBe('undefined');
+  });
+
+  it('converts objects to string', () => {
+    expect(formatError({code: 'ERR'})).toBe('[object Object]');
+  });
+});

--- a/src/tools/database/common/format-error.ts
+++ b/src/tools/database/common/format-error.ts
@@ -1,0 +1,7 @@
+/**
+ * Formats an unknown error value for display in tool error responses.
+ * Preserves error messages from Error instances while handling non-Error values.
+ */
+export function formatError(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/tools/database/common/pinecone-client.test.ts
+++ b/src/tools/database/common/pinecone-client.test.ts
@@ -1,0 +1,126 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+
+// Mock the Pinecone client
+vi.mock('@pinecone-database/pinecone', () => ({
+  Pinecone: vi.fn().mockImplementation((config) => ({
+    _config: config,
+  })),
+}));
+
+// Mock constants - we'll control PINECONE_API_KEY via stubEnv
+vi.mock('../../../constants.js', () => ({
+  get PINECONE_API_KEY() {
+    return process.env.PINECONE_API_KEY;
+  },
+}));
+
+// Mock version
+vi.mock('../../../version.js', () => ({
+  PINECONE_MCP_VERSION: '0.0.0-test',
+}));
+
+describe('pinecone-client', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('PINECONE_API_KEY', 'test-api-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  describe('getPineconeClient', () => {
+    it('throws when PINECONE_API_KEY is not set', async () => {
+      vi.stubEnv('PINECONE_API_KEY', '');
+
+      const {getPineconeClient} = await import('./pinecone-client.js');
+
+      expect(() => getPineconeClient()).toThrow('PINECONE_API_KEY environment variable is not set');
+    });
+
+    it('returns a Pinecone client when API key is set', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client = getPineconeClient();
+
+      expect(client).toBeDefined();
+      expect((client as unknown as {_config: unknown})._config).toEqual({
+        apiKey: 'test-api-key',
+        sourceTag: 'pinecone-mcp@0.0.0-test',
+      });
+    });
+
+    it('returns cached client on subsequent calls with same caller', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client1 = getPineconeClient();
+      const client2 = getPineconeClient();
+
+      expect(client1).toBe(client2);
+    });
+
+    it('returns cached client when caller has no model', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client1 = getPineconeClient();
+      const client2 = getPineconeClient({provider: 'anthropic'});
+
+      expect(client1).toBe(client2);
+    });
+
+    it('creates separate clients for different callers with models', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client1 = getPineconeClient({model: 'gpt-4'});
+      const client2 = getPineconeClient({model: 'claude-3'});
+
+      expect(client1).not.toBe(client2);
+    });
+
+    it('includes caller info in client config when model is provided', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client = getPineconeClient({provider: 'openai', model: 'gpt-4'});
+
+      expect((client as unknown as {_config: unknown})._config).toEqual({
+        apiKey: 'test-api-key',
+        sourceTag: 'pinecone-mcp@0.0.0-test',
+        caller: {provider: 'openai', model: 'gpt-4'},
+      });
+    });
+
+    it('includes caller info without provider when only model is provided', async () => {
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      const client = getPineconeClient({model: 'gpt-4'});
+
+      expect((client as unknown as {_config: unknown})._config).toEqual({
+        apiKey: 'test-api-key',
+        sourceTag: 'pinecone-mcp@0.0.0-test',
+        caller: {model: 'gpt-4'},
+      });
+    });
+  });
+
+  describe('clearClientCache', () => {
+    it('clears the client cache', async () => {
+      const {Pinecone} = await import('@pinecone-database/pinecone');
+      const {getPineconeClient, clearClientCache} = await import('./pinecone-client.js');
+      clearClientCache();
+
+      getPineconeClient();
+      expect(Pinecone).toHaveBeenCalledTimes(1);
+
+      clearClientCache();
+      getPineconeClient();
+      expect(Pinecone).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/tools/database/common/register-tool.test.ts
+++ b/src/tools/database/common/register-tool.test.ts
@@ -1,0 +1,141 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {z} from 'zod';
+
+// Mock the Pinecone client module
+const mockPineconeClient = {mockClient: true};
+vi.mock('./pinecone-client.js', () => ({
+  getPineconeClient: vi.fn().mockReturnValue(mockPineconeClient),
+}));
+
+describe('registerDatabaseTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('registers a tool with merged schema including LLM caller fields', async () => {
+    const {registerDatabaseTool} = await import('./register-tool.js');
+    const mockServer = {
+      registerTool: vi.fn(),
+    };
+
+    const inputSchema = {
+      indexName: z.string().describe('The index name'),
+    };
+
+    registerDatabaseTool(
+      mockServer as never,
+      'test-tool',
+      {description: 'A test tool', inputSchema},
+      async () => ({content: [{type: 'text', text: 'ok'}]}),
+    );
+
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+    const [name, config] = mockServer.registerTool.mock.calls[0];
+
+    expect(name).toBe('test-tool');
+    expect(config.description).toBe('A test tool');
+    expect(config.inputSchema).toHaveProperty('indexName');
+    expect(config.inputSchema).toHaveProperty('llm_provider');
+    expect(config.inputSchema).toHaveProperty('llm_model');
+  });
+
+  it('extracts LLM caller fields and passes remaining args to handler', async () => {
+    const {registerDatabaseTool} = await import('./register-tool.js');
+    const mockServer = {
+      registerTool: vi.fn(),
+    };
+
+    const handlerArgs: Record<string, unknown>[] = [];
+    const handler = vi.fn().mockImplementation(async (args) => {
+      handlerArgs.push(args);
+      return {content: [{type: 'text', text: 'ok'}]};
+    });
+
+    const inputSchema = {
+      indexName: z.string(),
+      query: z.string(),
+    };
+
+    registerDatabaseTool(
+      mockServer as never,
+      'test-tool',
+      {description: 'Test', inputSchema},
+      handler,
+    );
+
+    // Get the registered handler and call it
+    const registeredHandler = mockServer.registerTool.mock.calls[0][2];
+    await registeredHandler({
+      indexName: 'my-index',
+      query: 'search term',
+      llm_provider: 'anthropic',
+      llm_model: 'claude-3',
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handlerArgs[0]).toEqual({
+      indexName: 'my-index',
+      query: 'search term',
+    });
+    expect(handlerArgs[0]).not.toHaveProperty('llm_provider');
+    expect(handlerArgs[0]).not.toHaveProperty('llm_model');
+  });
+
+  it('creates Pinecone client with caller info from LLM fields', async () => {
+    const {getPineconeClient} = await import('./pinecone-client.js');
+    const {registerDatabaseTool} = await import('./register-tool.js');
+    const mockServer = {
+      registerTool: vi.fn(),
+    };
+
+    const handler = vi.fn().mockResolvedValue({content: [{type: 'text', text: 'ok'}]});
+
+    registerDatabaseTool(
+      mockServer as never,
+      'test-tool',
+      {description: 'Test', inputSchema: {indexName: z.string()}},
+      handler,
+    );
+
+    const registeredHandler = mockServer.registerTool.mock.calls[0][2];
+    await registeredHandler({
+      indexName: 'my-index',
+      llm_provider: 'openai',
+      llm_model: 'gpt-4',
+    });
+
+    expect(getPineconeClient).toHaveBeenCalledWith({
+      provider: 'openai',
+      model: 'gpt-4',
+    });
+  });
+
+  it('passes Pinecone client to handler', async () => {
+    const {registerDatabaseTool} = await import('./register-tool.js');
+    const mockServer = {
+      registerTool: vi.fn(),
+    };
+
+    let receivedClient: unknown;
+    const handler = vi.fn().mockImplementation(async (_args, pc) => {
+      receivedClient = pc;
+      return {content: [{type: 'text', text: 'ok'}]};
+    });
+
+    registerDatabaseTool(
+      mockServer as never,
+      'test-tool',
+      {description: 'Test', inputSchema: {indexName: z.string()}},
+      handler,
+    );
+
+    const registeredHandler = mockServer.registerTool.mock.calls[0][2];
+    await registeredHandler({indexName: 'my-index'});
+
+    expect(receivedClient).toBe(mockPineconeClient);
+  });
+});

--- a/src/tools/database/create-index-for-model.test.ts
+++ b/src/tools/database/create-index-for-model.test.ts
@@ -152,7 +152,7 @@ describe('create-index-for-model tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: API error'}],
+      content: [{type: 'text', text: 'API error'}],
     });
   });
 });

--- a/src/tools/database/create-index-for-model.ts
+++ b/src/tools/database/create-index-for-model.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS =
@@ -109,7 +110,7 @@ export function addCreateIndexForModelTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/describe-index-stats.test.ts
+++ b/src/tools/database/describe-index-stats.test.ts
@@ -68,7 +68,7 @@ describe('describe-index-stats tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: API error'}],
+      content: [{type: 'text', text: 'API error'}],
     });
   });
 });

--- a/src/tools/database/describe-index-stats.ts
+++ b/src/tools/database/describe-index-stats.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Describe the statistics of a Pinecone index and its namespaces';
@@ -27,7 +28,7 @@ export function addDescribeIndexStatsTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/describe-index.test.ts
+++ b/src/tools/database/describe-index.test.ts
@@ -66,7 +66,7 @@ describe('describe-index tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: Index not found'}],
+      content: [{type: 'text', text: 'Index not found'}],
     });
   });
 });

--- a/src/tools/database/describe-index.ts
+++ b/src/tools/database/describe-index.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Describe the configuration of a Pinecone index';
@@ -26,7 +27,7 @@ export function addDescribeIndexTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/list-indexes.test.ts
+++ b/src/tools/database/list-indexes.test.ts
@@ -66,7 +66,7 @@ describe('list-indexes tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: API error'}],
+      content: [{type: 'text', text: 'API error'}],
     });
   });
 

--- a/src/tools/database/list-indexes.ts
+++ b/src/tools/database/list-indexes.ts
@@ -1,4 +1,5 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {formatError} from './common/format-error.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = `List all Pinecone indexes`;
@@ -20,7 +21,7 @@ export function addListIndexesTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/rerank-documents.test.ts
+++ b/src/tools/database/rerank-documents.test.ts
@@ -97,7 +97,7 @@ describe('rerank-documents tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: Rerank failed'}],
+      content: [{type: 'text', text: 'Rerank failed'}],
     });
   });
 });

--- a/src/tools/database/rerank-documents.ts
+++ b/src/tools/database/rerank-documents.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {RERANK_MODEL_SCHEMA} from './common/rerank-model.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
@@ -63,7 +64,7 @@ export function addRerankDocumentsTool(server: McpServer) {
           content: [{type: 'text' as const, text: JSON.stringify(results, null, 2)}],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/search-records.test.ts
+++ b/src/tools/database/search-records.test.ts
@@ -104,7 +104,7 @@ describe('search-records tool', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: Search failed'}],
+      content: [{type: 'text', text: 'Search failed'}],
     });
   });
 });

--- a/src/tools/database/search-records.ts
+++ b/src/tools/database/search-records.ts
@@ -1,5 +1,6 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {RERANK_MODEL_SCHEMA} from './common/rerank-model.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 import {SEARCH_QUERY_SCHEMA} from './common/search-query.js';
@@ -84,7 +85,7 @@ export function addSearchRecordsTool(server: McpServer) {
           ],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );

--- a/src/tools/database/upsert-records.handler.test.ts
+++ b/src/tools/database/upsert-records.handler.test.ts
@@ -67,7 +67,7 @@ describe('upsert-records tool handler', () => {
 
     expect(result).toEqual({
       isError: true,
-      content: [{type: 'text', text: 'Error: API error'}],
+      content: [{type: 'text', text: 'API error'}],
     });
   });
 

--- a/src/tools/database/upsert-records.ts
+++ b/src/tools/database/upsert-records.ts
@@ -1,6 +1,7 @@
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {IntegratedRecord} from '@pinecone-database/pinecone';
 import {z} from 'zod';
+import {formatError} from './common/format-error.js';
 import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Insert or update records in a Pinecone index';
@@ -56,7 +57,7 @@ export function addUpsertRecordsTool(server: McpServer) {
           content: [{type: 'text' as const, text: 'Data upserted successfully'}],
         };
       } catch (e) {
-        return {isError: true, content: [{type: 'text' as const, text: String(e)}]};
+        return {isError: true, content: [{type: 'text' as const, text: formatError(e)}]};
       }
     },
   );


### PR DESCRIPTION
## Summary

- Introduces a `formatError` helper function in `src/tools/database/common/format-error.ts` for consistent error formatting across all tool handlers
- Replaces `String(e)` with `formatError(e)` in 8 tool handler files to extract clean error messages from Error instances
- Error messages no longer include the redundant "Error: " prefix from `Error.toString()`

## Problem

Tool handlers used `String(e)` to convert errors to strings, which loses error details and produces verbose messages with redundant "Error: " prefixes. For example, `String(new Error("API failed"))` produces `"Error: API failed"` instead of just `"API failed"`.

## Solution

The `formatError` helper extracts just the message from Error instances while maintaining fallback behavior for non-Error values:

```typescript
export function formatError(e: unknown): string {
  return e instanceof Error ? e.message : String(e);
}
```

## Test Plan

- [x] Unit tests for `formatError` helper covering Error instances, Error subclasses, strings, numbers, null, undefined, and objects
- [x] Updated existing error response tests to expect cleaner error messages
- [x] All 90 tests pass
- [x] Build passes

## Linear Issue

Closes SDK-92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies error handling across database tools and tightens test coverage.
> 
> - Introduces `formatError` to extract clean messages from errors and replaces `String(e)` in `list-indexes`, `describe-index`, `describe-index-stats`, `create-index-for-model`, `search-records`, `cascading-search`, `rerank-documents`, and `upsert-records`
> - Updates error responses to omit the redundant "Error: " prefix; adjusts existing tests and adds new tests for `format-error`, `pinecone-client`, `register-tool`, and the main entry (`index.test.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bfe81e72380eed82dc330d47c329546b7f24bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->