### PR TITLE
chore: exclude test files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   },
   "private": false,
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
+    "!dist/test-utils"
   ],
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

The published npm package was including compiled test files and test utilities, unnecessarily increasing the package size. This PR adds negation patterns to the `files` field in `package.json` to exclude these files from the published tarball.

**Before:**
- 85 files
- 25.3 kB package size
- 113.9 kB unpacked

**After:**
- 45 files
- 16.4 kB package size (35% smaller)
- 54.0 kB unpacked (53% smaller)

## Changes

Updated `package.json` to exclude test files from the package:

```json
"files": [
  "dist",
  "!dist/**/*.test.js",
  "!dist/**/*.test.d.ts",
  "!dist/test-utils"
]
```

## Test plan

- [x] All 90 unit tests pass
- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` confirms test files are excluded
- [x] ESLint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces published package size by excluding compiled tests and test utilities from `npm publish`.
> 
> - Updates `package.json` `files` to include `dist` while negating `!dist/**/*.test.js`, `!dist/**/*.test.d.ts`, and `!dist/test-utils`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73f81973f4b3962a1edbd1ed1d7b1cbc4fbfdcd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->