### PR TITLE
docs: add language labels to code blocks for syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Next, you will need to configure your AI assistant to use the MCP server.
 
 To add the Pinecone MCP server to a project, create a `.cursor/mcp.json` file in the project root (if it doesn't already exist) and add the following configuration:
 
-```
+```json
 {
   "mcpServers": {
     "pinecone": {
@@ -54,7 +54,7 @@ It is recommended to use rules to instruct Cursor on proper usage of the MCP ser
 
 Use Claude desktop to locate the `claude_desktop_config.json` file by navigating to **Settings > Developer > Edit Config**. Add the following configuration:
 
-```
+```json
 {
   "mcpServers": {
     "pinecone": {
@@ -76,13 +76,13 @@ Restart Claude desktop. On the new chat screen, you should see a hammer (MCP) ic
 
 To install this as a [Gemini CLI](https://github.com/google-gemini/gemini-cli) extension, run the following command:
 
-```
+```bash
 gemini extensions install https://github.com/pinecone-io/pinecone-mcp
 ```
 
 You will need to provide your Pinecone API key in the `PINECONE_API_KEY` environment variable.
 
-```
+```bash
 export PINECONE_API_KEY=<your pinecone api key>
 ```
 


### PR DESCRIPTION
## Summary

- Adds language labels (`json`, `bash`) to all code blocks in the README to enable syntax highlighting

Code blocks were missing language identifiers, which meant they rendered as plain text without syntax highlighting in GitHub and other Markdown viewers.

## Changes

- Added `json` label to the Cursor and Claude Desktop configuration examples
- Added `bash` label to the Gemini CLI installation and environment variable examples

## Test plan

- [x] Verify README renders correctly with syntax highlighting on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances README syntax highlighting by adding language labels to code blocks.
> 
> - Adds `json` to Cursor and Claude Desktop configuration examples in `README.md`
> - Adds `bash` to Gemini CLI install and environment variable examples
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da78893fc58c43ab27e1a2606c0f430e620a5db0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->