### PR TITLE
fix(ci): add GH_TOKEN to release workflow for draft release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,8 @@ jobs:
       - name: Create draft release with notes (prod)
         if: github.event.inputs.releaseMode == 'prod'
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "v${{ steps.version-bump-prod.outputs.version }}" \
             --draft \


### PR DESCRIPTION
## Summary

Fixes the release workflow failure where the "Create draft release with notes" step was failing with exit code 4.

**Problem:** The `gh release create` command requires authentication via the `GH_TOKEN` or `GITHUB_TOKEN` environment variable. While the workflow declares `permissions: contents: write` at the job level, the gh CLI still requires the token to be explicitly passed.

**Solution:** Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the environment for the draft release creation step.

**Related:** https://github.com/pinecone-io/pinecone-mcp/actions/runs/21404698668/job/61625174745

## Test plan

- [ ] Merge this PR
- [ ] Run the release workflow manually to verify the draft release is created successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the `gh release create` step in the release workflow authenticates properly.
> 
> - Adds `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `Create draft release with notes (prod)` step in `.github/workflows/release.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df11af1957a71e1d23c6c1190f9e2d0f956b8fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->