### PR TITLE
fix(ci): use github.token instead of secrets.GITHUB_TOKEN for gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         if: github.event.inputs.releaseMode == 'prod'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "v${{ steps.version-bump-prod.outputs.version }}" \
             --draft \


### PR DESCRIPTION
## Summary
- Fixes release workflow failure by using `github.token` instead of `secrets.GITHUB_TOKEN` for the `GH_TOKEN` environment variable in the draft release creation step

## Root Cause
The GitHub CLI (`gh`) requires `GH_TOKEN` to be set to `github.token` in GitHub Actions workflows. Using `secrets.GITHUB_TOKEN` caused the workflow to fail with exit code 4:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

## Test Plan
- [ ] Manually trigger the release workflow in a test run
- [ ] Verify the draft release is created successfully
- [ ] Confirm no exit code 4 errors

Fixes https://github.com/pinecone-io/pinecone-mcp/actions/runs/21404698668

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI/workflow change limited to GitHub release automation; minimal blast radius outside the release job.
> 
> **Overview**
> Fixes the GitHub Actions release workflow by changing the `GH_TOKEN` env var for the `gh release create` step from `secrets.GITHUB_TOKEN` to `github.token`, preventing draft release creation failures during prod releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cefae05461d4887a85f3efa33b0a9aa1d7e54db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->