### PR TITLE
feat: use settings in gemini extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,7 @@ To install this as a [Gemini CLI](https://github.com/google-gemini/gemini-cli) e
 gemini extensions install https://github.com/pinecone-io/pinecone-mcp
 ```
 
-You will need to provide your Pinecone API key in the `PINECONE_API_KEY` environment variable.
-
-```bash
-export PINECONE_API_KEY=<your pinecone api key>
-```
+You will need to provide your Pinecone API key when prompted.
 
 When you run `gemini` and press `ctrl+t`, `pinecone` should now be shown in the list of installed MCP servers.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -6,5 +6,12 @@
       "command": "npx",
       "args": ["-y", "@pinecone-database/mcp"]
     }
-  }
+  },
+  "settings": [
+    {
+      "name": "Pinecone API Key",
+      "description": "Pinecone API Key",
+      "envVar": "PINECONE_API_KEY"
+    }
+  ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -11,7 +11,8 @@
     {
       "name": "Pinecone API Key",
       "description": "Pinecone API Key",
-      "envVar": "PINECONE_API_KEY"
+      "envVar": "PINECONE_API_KEY",
+      "sensitive": true   
     }
   ]
 }


### PR DESCRIPTION
### Overview

Gemini extensions [now support settings](https://developers.googleblog.com/making-gemini-cli-extensions-easier-to-use/) making it easier to take in user inputs.

Earlier, it is very easy to forget setting PINECONE_API_KEY as the env variable making the Pinecone extension installation fail. With Gemini extension settings, the user is prompted to set Pinecone API Key making the experience seamless.

Screenshot showing extension installation waiting for user input for Pinecone API Key:
<img width="1262" height="271" alt="Screenshot 2026-02-21 at 10 16 50 AM" src="https://github.com/user-attachments/assets/52ce751f-8a40-4471-b87a-b315abcfb809" />

Screenshot post successful installation:
<img width="1262" height="283" alt="Screenshot 2026-02-24 at 10 55 58 PM" src="https://github.com/user-attachments/assets/c4510e62-aae2-410e-bf82-c995a1f30533" />


### Link to issue

N/A

### Type

- [ ] Bug fix
- [ ] New feature
- [x ] Improvement
- [ ] Infrastructure change
- [ ] Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration/metadata and documentation-only change; no runtime server logic, auth flow, or data handling code is modified.
> 
> **Overview**
> Gemini CLI installation is updated to use extension `settings` so users are prompted for the Pinecone API key, storing it in `PINECONE_API_KEY` as a sensitive value.
> 
> Documentation is adjusted accordingly, removing the manual `export PINECONE_API_KEY=...` step and noting the interactive prompt during `gemini extensions install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22fc34e2f9c565c07f7f173cf2212b6fe4e9b6cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->