### PR TITLE
chore(ci): move security audit from PR checks to release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,3 @@ jobs:
 
       - name: Check formatting
         run: npx prettier --check 'src/**/*.ts' '*.json' '.prettierrc'
-
-      - name: Security audit
-        run: npm audit --audit-level=high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
           git_email: 'clients@pinecone.io'
           git_username: ${{ github.actor }}
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       ##### VERSION BUMP #####
       - name: 'Bump version for production release'
         if: inputs.releaseMode == 'prod'


### PR DESCRIPTION
## Summary

Bugbot already handles vulnerability scanning on PRs, making the `npm audit` step in CI redundant there. Running it in PR CI also causes friction by blocking merges for vulnerabilities unrelated to the PR's changes. Moving the check to the release workflow ensures high/critical CVEs still block publishing without disrupting PR flow.

## Changes

- Removed `npm audit --audit-level=high` from `.github/workflows/ci.yml`
- Added `npm audit --audit-level=high` to `.github/workflows/release.yml` after the `Setup` step, before any version bumping — so a vulnerability stops the release before anything is committed or published to npm

## Test Plan

- [ ] CI passes on this PR (no audit step to fail)
- [ ] Release workflow visually confirmed to have audit step in correct position

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release pipeline behavior changes: publishes will now fail early on high/critical `npm audit` findings, and PR CI will no longer surface those failures. Low code risk but can impact release velocity if the audit produces new failures.
> 
> **Overview**
> **Shifts vulnerability gating from PR CI to release time.** The `npm audit --audit-level=high` step is removed from `.github/workflows/ci.yml`, so pull-request checks no longer fail due to audit results.
> 
> **Adds a release gate before any version/publish side effects.** `.github/workflows/release.yml` now runs the same `npm audit` immediately after `Setup` and before version bumping, ensuring high/critical findings block the release workflow early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a468b36573970c764d14d61decc46ebf41b9074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->