### PR TITLE
Fix upsert-records schema for Claude tools

### DIFF
--- a/src/tools/database/upsert-records.test.ts
+++ b/src/tools/database/upsert-records.test.ts
@@ -1,5 +1,21 @@
 import {describe, it, expect} from 'vitest';
+import {z} from 'zod';
 import {FIELD_VALUE_SCHEMA, RECORD_SCHEMA} from './upsert-records.js';
+
+function findSchemaCompositionKeywords(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const keywords: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
+      keywords.push(key);
+    }
+    keywords.push(...findSchemaCompositionKeywords(nested));
+  }
+  return keywords;
+}
 
 describe('FIELD_VALUE_SCHEMA', () => {
   it('accepts string values', () => {
@@ -33,6 +49,16 @@ describe('FIELD_VALUE_SCHEMA', () => {
   it('rejects arrays with non-string elements', () => {
     const result = FIELD_VALUE_SCHEMA.safeParse(['a', 123, 'b']);
     expect(result.success).toBe(false);
+  });
+
+  it('exports without schema composition keywords rejected by Claude tools', () => {
+    const inputSchema = z.object({
+      records: z.array(RECORD_SCHEMA),
+    });
+
+    const jsonSchema = z.toJSONSchema(inputSchema);
+
+    expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
   });
 });
 

--- a/src/tools/database/upsert-records.ts
+++ b/src/tools/database/upsert-records.ts
@@ -6,8 +6,20 @@ import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Insert or update records in a Pinecone index';
 
+function isFieldValue(value: unknown) {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+  );
+}
+
 export const FIELD_VALUE_SCHEMA = z
-  .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+  .any()
+  .refine(isFieldValue, {
+    message: 'A field value must be a string, number, boolean, or array of strings.',
+  })
   .describe('A field value. Must be a string, number, boolean, or array of strings.');
 
 export const RECORD_SCHEMA = z


### PR DESCRIPTION
### Overview

Fixes the `upsert-records` MCP tool schema so it no longer exports JSON Schema composition keywords rejected by Claude tool schemas.

The runtime validator still accepts the same supported field values:

- string
- number
- boolean
- array of strings

and still rejects unsupported values such as `null`, nested objects, and arrays with non-string elements. The change replaces the Zod union with a refined schema so JSON Schema generation does not emit `anyOf`.

I also added a focused regression test that generates the record input schema and checks for `anyOf`, `oneOf`, or `allOf`.

### Link to issue

Fixes https://github.com/pinecone-io/pinecone-mcp/issues/53

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Infrastructure change
- [ ] Documentation

### Validation

- `npm run lint`
- `npm test`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema export and validation shape only for the upsert-records MCP tool; runtime accepted values are intended to stay the same with added test coverage.
> 
> **Overview**
> Fixes Claude tool registration for **`upsert-records`** by changing how **`FIELD_VALUE_SCHEMA`** is defined so generated JSON Schema no longer includes **`anyOf` / `oneOf` / `allOf`**, which those clients reject.
> 
> The previous **`z.union([...])`** is replaced with **`z.any().refine(isFieldValue, ...)`**, using a small **`isFieldValue`** helper that still allows strings, numbers, booleans, and string arrays and rejects the same invalid shapes at parse time.
> 
> A regression test builds the tool input schema via **`z.toJSONSchema`** and asserts no composition keywords appear anywhere in the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f41000b3e974309b46a65ade3f6ad36d0e7de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->