### PR TITLE
test: central guard for tool schema composition keywords

### DIFF
--- a/src/tools/database/rerank-documents.test.ts
+++ b/src/tools/database/rerank-documents.test.ts
@@ -1,24 +1,10 @@
 import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {z} from 'zod';
 import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
 import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
-import {DOCUMENTS_SCHEMA, SCHEMA} from './rerank-documents.js';
+import {DOCUMENTS_SCHEMA} from './rerank-documents.js';
 
-function findSchemaCompositionKeywords(value: unknown): string[] {
-  if (!value || typeof value !== 'object') {
-    return [];
-  }
-
-  const keywords: string[] = [];
-  for (const [key, nested] of Object.entries(value)) {
-    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
-      keywords.push(key);
-    }
-    keywords.push(...findSchemaCompositionKeywords(nested));
-  }
-  return keywords;
-}
-
+// The generated JSON Schema for this tool is guarded centrally in
+// src/tools/tool-schemas.test.ts; these cases only cover runtime validation.
 describe('DOCUMENTS_SCHEMA', () => {
   it('accepts an array of text documents', () => {
     expect(DOCUMENTS_SCHEMA.parse(['a', 'b'])).toEqual(['a', 'b']);
@@ -44,14 +30,6 @@ describe('DOCUMENTS_SCHEMA', () => {
 
   it('rejects records with non-string values', () => {
     expect(DOCUMENTS_SCHEMA.safeParse([{title: 'Doc', score: 1}]).success).toBe(false);
-  });
-
-  it('exports without schema composition keywords rejected by Claude tools', () => {
-    const inputSchema = z.object(SCHEMA);
-
-    const jsonSchema = z.toJSONSchema(inputSchema);
-
-    expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
   });
 });
 

--- a/src/tools/database/rerank-documents.test.ts
+++ b/src/tools/database/rerank-documents.test.ts
@@ -1,6 +1,59 @@
 import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {z} from 'zod';
 import {createMockPinecone, MockPinecone} from '../../test-utils/mock-pinecone.js';
 import {createMockServer, MockServer} from '../../test-utils/mock-server.js';
+import {DOCUMENTS_SCHEMA, SCHEMA} from './rerank-documents.js';
+
+function findSchemaCompositionKeywords(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const keywords: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
+      keywords.push(key);
+    }
+    keywords.push(...findSchemaCompositionKeywords(nested));
+  }
+  return keywords;
+}
+
+describe('DOCUMENTS_SCHEMA', () => {
+  it('accepts an array of text documents', () => {
+    expect(DOCUMENTS_SCHEMA.parse(['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('accepts an array of string records', () => {
+    const docs = [{title: 'Doc 1', body: 'Content'}];
+    expect(DOCUMENTS_SCHEMA.parse(docs)).toEqual(docs);
+  });
+
+  it('accepts an empty array', () => {
+    expect(DOCUMENTS_SCHEMA.parse([])).toEqual([]);
+  });
+
+  it('rejects non-array values', () => {
+    expect(DOCUMENTS_SCHEMA.safeParse('not an array').success).toBe(false);
+    expect(DOCUMENTS_SCHEMA.safeParse({title: 'Doc'}).success).toBe(false);
+  });
+
+  it('rejects arrays that mix strings and records', () => {
+    expect(DOCUMENTS_SCHEMA.safeParse(['a', {title: 'Doc'}]).success).toBe(false);
+  });
+
+  it('rejects records with non-string values', () => {
+    expect(DOCUMENTS_SCHEMA.safeParse([{title: 'Doc', score: 1}]).success).toBe(false);
+  });
+
+  it('exports without schema composition keywords rejected by Claude tools', () => {
+    const inputSchema = z.object(SCHEMA);
+
+    const jsonSchema = z.toJSONSchema(inputSchema);
+
+    expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
+  });
+});
 
 // Mock the pinecone-client module
 vi.mock('./common/pinecone-client.js', () => ({

--- a/src/tools/database/rerank-documents.ts
+++ b/src/tools/database/rerank-documents.ts
@@ -27,11 +27,28 @@ export const RerankDocumentsOptions = z
   })
   .optional();
 
-const Documents = z
-  .union([
-    z.array(z.string()).describe('An array of text documents to rerank.'),
-    z.array(z.record(z.string(), z.string())).describe('An array of records to rerank.'),
-  ])
+function isStringRecord(value: unknown) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === 'string')
+  );
+}
+
+function isDocumentSet(value: unknown) {
+  return (
+    Array.isArray(value) &&
+    (value.every((item) => typeof item === 'string') || value.every(isStringRecord))
+  );
+}
+
+export const DOCUMENTS_SCHEMA = z
+  .any()
+  .refine(isDocumentSet, {
+    message:
+      'Documents must be an array of text documents (strings) or an array of records with string values.',
+  })
   .describe(
     `A set of documents to rerank. Can either be an array of text documents
     (strings) or an array of records.`,
@@ -40,7 +57,7 @@ const Documents = z
 export const SCHEMA = {
   model: RERANK_MODEL_SCHEMA,
   query: z.string().describe('The query to rerank documents against.'),
-  documents: Documents,
+  documents: DOCUMENTS_SCHEMA,
   options: RerankDocumentsOptions,
 };
 

--- a/src/tools/database/upsert-records.test.ts
+++ b/src/tools/database/upsert-records.test.ts
@@ -1,22 +1,8 @@
 import {describe, it, expect} from 'vitest';
-import {z} from 'zod';
 import {FIELD_VALUE_SCHEMA, RECORD_SCHEMA} from './upsert-records.js';
 
-function findSchemaCompositionKeywords(value: unknown): string[] {
-  if (!value || typeof value !== 'object') {
-    return [];
-  }
-
-  const keywords: string[] = [];
-  for (const [key, nested] of Object.entries(value)) {
-    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
-      keywords.push(key);
-    }
-    keywords.push(...findSchemaCompositionKeywords(nested));
-  }
-  return keywords;
-}
-
+// The generated JSON Schema for this tool is guarded centrally in
+// src/tools/tool-schemas.test.ts; these cases only cover runtime validation.
 describe('FIELD_VALUE_SCHEMA', () => {
   it('accepts string values', () => {
     expect(FIELD_VALUE_SCHEMA.parse('hello')).toBe('hello');
@@ -49,16 +35,6 @@ describe('FIELD_VALUE_SCHEMA', () => {
   it('rejects arrays with non-string elements', () => {
     const result = FIELD_VALUE_SCHEMA.safeParse(['a', 123, 'b']);
     expect(result.success).toBe(false);
-  });
-
-  it('exports without schema composition keywords rejected by Claude tools', () => {
-    const inputSchema = z.object({
-      records: z.array(RECORD_SCHEMA),
-    });
-
-    const jsonSchema = z.toJSONSchema(inputSchema);
-
-    expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
   });
 });
 

--- a/src/tools/database/upsert-records.test.ts
+++ b/src/tools/database/upsert-records.test.ts
@@ -1,5 +1,21 @@
 import {describe, it, expect} from 'vitest';
+import {z} from 'zod';
 import {FIELD_VALUE_SCHEMA, RECORD_SCHEMA} from './upsert-records.js';
+
+function findSchemaCompositionKeywords(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const keywords: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
+      keywords.push(key);
+    }
+    keywords.push(...findSchemaCompositionKeywords(nested));
+  }
+  return keywords;
+}
 
 describe('FIELD_VALUE_SCHEMA', () => {
   it('accepts string values', () => {
@@ -33,6 +49,16 @@ describe('FIELD_VALUE_SCHEMA', () => {
   it('rejects arrays with non-string elements', () => {
     const result = FIELD_VALUE_SCHEMA.safeParse(['a', 123, 'b']);
     expect(result.success).toBe(false);
+  });
+
+  it('exports without schema composition keywords rejected by Claude tools', () => {
+    const inputSchema = z.object({
+      records: z.array(RECORD_SCHEMA),
+    });
+
+    const jsonSchema = z.toJSONSchema(inputSchema);
+
+    expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
   });
 });
 

--- a/src/tools/database/upsert-records.ts
+++ b/src/tools/database/upsert-records.ts
@@ -6,8 +6,20 @@ import {registerDatabaseTool} from './common/register-tool.js';
 
 const INSTRUCTIONS = 'Insert or update records in a Pinecone index';
 
+function isFieldValue(value: unknown) {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+  );
+}
+
 export const FIELD_VALUE_SCHEMA = z
-  .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+  .any()
+  .refine(isFieldValue, {
+    message: 'A field value must be a string, number, boolean, or array of strings.',
+  })
   .describe('A field value. Must be a string, number, boolean, or array of strings.');
 
 export const RECORD_SCHEMA = z

--- a/src/tools/tool-schemas.test.ts
+++ b/src/tools/tool-schemas.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
+
+// Claude (and other clients) reject tool input schemas that contain JSON Schema
+// composition keywords, so no registered tool may emit them. This guard boots
+// the real server and inspects the schemas exactly as a client receives them
+// via `tools/list`, so it covers every current and future tool automatically
+// -- no per-tool assertion required. See #89 and #93 for the tools that
+// originally tripped this.
+const COMPOSITION_KEYWORDS = ['anyOf', 'oneOf', 'allOf'];
+
+function findSchemaCompositionKeywords(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const keywords: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    if (COMPOSITION_KEYWORDS.includes(key)) {
+      keywords.push(key);
+    }
+    keywords.push(...findSchemaCompositionKeywords(nested));
+  }
+  return keywords;
+}
+
+describe('registered tool schemas', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Database tools only register when an API key is present.
+    vi.stubEnv('PINECONE_API_KEY', 'test-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('do not emit JSON Schema composition keywords rejected by Claude tools', async () => {
+    const {default: setupServer} = await import('../server.js');
+    const server = await setupServer();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({name: 'schema-guard', version: '0.0.0'});
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const {tools} = await client.listTools();
+
+      // Sanity check: fail loudly if tool discovery is broken, so a green run
+      // can't mean "no tools were checked".
+      expect(tools.length).toBeGreaterThan(0);
+
+      const offenders = tools
+        .map((tool) => ({
+          name: tool.name,
+          keywords: findSchemaCompositionKeywords(tool.inputSchema),
+        }))
+        .filter((entry) => entry.keywords.length > 0);
+
+      expect(offenders).toEqual([]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Overview

Debt-reduction follow-up to #89 and #93. Both of those PRs fixed a single MCP tool whose generated JSON Schema emitted `anyOf` (which Claude tool schemas reject), and each shipped its own per-tool regression test with a copy-pasted `findSchemaCompositionKeywords` helper.

That pattern is whack-a-mole:
- The next `z.union(...)` added to any tool reintroduces the bug silently until someone remembers to write yet another per-tool assertion.
- The per-tool tests convert Zod via `z.toJSONSchema` (full Zod, `io: 'output'`), **not** the path the MCP SDK actually uses at registration (`zod/v4-mini`'s `toJSONSchema` with `io: 'input'`) — so they could pass while the shipped tool still breaks.

### Change

Add a single guard (`src/tools/tool-schemas.test.ts`) that boots the **real** server over an in-memory transport and inspects every tool's `inputSchema` exactly as a client receives it via `tools/list`. This:

- covers **all** current and future tools automatically — no per-tool assertion to remember,
- has **no fidelity gap** — it exercises the SDK's real conversion path,
- fails loudly if tool discovery returns nothing (so a green run can't mean "checked nothing").

I verified it has teeth: temporarily reintroducing a `z.union` makes it fail with `{ name: 'rerank-documents', keywords: ['anyOf'] }`.

The now-redundant per-tool composition tests (and their duplicated helpers) are removed from `upsert-records.test.ts` and `rerank-documents.test.ts`; their runtime validation coverage is kept.

### ⚠️ Stacked on #89 and #93

The guard only passes once **both** tool fixes are in `main`, so this branch includes them. Until #89 and #93 merge, this PR's diff will show their commits too. **The only new change to review here is the final commit** (`test: guard all tool schemas…`). Merge order: #89 → #93 → this. It will rebase cleanly onto `main` once they land.

### Type

- [x] Infrastructure change (test hardening)

### Validation

- `npm run lint`
- `npm test` (97 passing; guard verified to fail on a reintroduced union)
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure plus schema-shape refactors that preserve validation semantics; no production API or auth changes.
> 
> **Overview**
> Adds **`src/tools/tool-schemas.test.ts`**, which starts the real MCP server (in-memory transport) and asserts every registered tool’s `inputSchema` from `tools/list` contains no `anyOf`, `oneOf`, or `allOf`—the keywords Claude rejects—so new tools are covered without per-tool copy-paste tests.
> 
> **`rerank-documents`** and **`upsert-records`** replace `z.union(...)` with `z.any().refine(...)` for `DOCUMENTS_SCHEMA` and `FIELD_VALUE_SCHEMA` so runtime validation stays the same but emitted JSON Schema avoids unions. Per-tool tests drop duplicated composition-keyword checks and keep **runtime** Zod parse cases, with comments pointing at the central guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0046eaf8d527d2de6a4c4f141310630e3d5ceb57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->