### PR TITLE
fix: adapt to Pinecone SDK v8 breaking API changes (supersedes #112)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@pinecone-database/pinecone": "^6.1.4",
+        "@pinecone-database/pinecone": "^8.2.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -373,12 +373,12 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-6.1.4.tgz",
-      "integrity": "sha512-wkipvpkBYNGYDeYj4azVVyCzSrekJE3Pgo0HImkbw80SGnTo9gz5kSbDCXCfVvFnhqC2q4nGikdTUvFCDiuruA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-8.2.0.tgz",
+      "integrity": "sha512-4Lzn+Ph4Lmf8ZEm2Ky1WGgPJJtoMtjSCmsT6bdHpd8nhkUnCQqk/NsbPYglx7irWYJpb2zBE+wehNBfoCeJ6Qw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
-    "@pinecone-database/pinecone": "^6.1.4",
+    "@pinecone-database/pinecone": "^8.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/tools/database/cascading-search.test.ts
+++ b/src/tools/database/cascading-search.test.ts
@@ -111,10 +111,11 @@ describe('cascading-search tool', () => {
 
     // Should only pass one document to rerank (deduplicated)
     expect(mockPc.inference.rerank).toHaveBeenCalledWith(
-      'bge-reranker-v2-m3',
-      'test query',
-      [{content: 'shared content'}], // First occurrence is kept
-      expect.any(Object),
+      expect.objectContaining({
+        model: 'bge-reranker-v2-m3',
+        query: 'test query',
+        documents: [{content: 'shared content'}], // First occurrence is kept
+      }),
     );
   });
 
@@ -133,10 +134,12 @@ describe('cascading-search tool', () => {
     });
 
     expect(mockPc.inference.rerank).toHaveBeenCalledWith(
-      'bge-reranker-v2-m3',
-      'test query',
-      expect.any(Array),
-      expect.objectContaining({topN: 0}),
+      expect.objectContaining({
+        model: 'bge-reranker-v2-m3',
+        query: 'test query',
+        documents: expect.any(Array),
+        topN: 0,
+      }),
     );
   });
 

--- a/src/tools/database/cascading-search.ts
+++ b/src/tools/database/cascading-search.ts
@@ -99,15 +99,13 @@ export function addCascadingSearchTool(server: McpServer) {
 
         const rerankedResults =
           deduplicatedResultsArray.length > 0
-            ? await pc.inference.rerank(
-                rerank.model,
-                rerank.query || query.inputs.text,
-                deduplicatedResultsArray,
-                {
-                  topN: rerank.topN ?? query.topK,
-                  rankFields: rerank.rankFields,
-                },
-              )
+            ? await pc.inference.rerank({
+                model: rerank.model,
+                query: rerank.query || query.inputs.text,
+                documents: deduplicatedResultsArray,
+                topN: rerank.topN ?? query.topK,
+                rankFields: rerank.rankFields,
+              })
             : [];
 
         const warning =

--- a/src/tools/database/rerank-documents.test.ts
+++ b/src/tools/database/rerank-documents.test.ts
@@ -104,12 +104,12 @@ describe('rerank-documents tool', () => {
       options: {topN: 2},
     });
 
-    expect(mockPc.inference.rerank).toHaveBeenCalledWith(
-      'bge-reranker-v2-m3',
-      'test query',
-      ['doc 1', 'doc 2', 'doc 3'],
-      {topN: 2},
-    );
+    expect(mockPc.inference.rerank).toHaveBeenCalledWith({
+      model: 'bge-reranker-v2-m3',
+      query: 'test query',
+      documents: ['doc 1', 'doc 2', 'doc 3'],
+      topN: 2,
+    });
     expect(result).toEqual({
       content: [{type: 'text', text: JSON.stringify(mockResults, null, 2)}],
     });
@@ -128,12 +128,13 @@ describe('rerank-documents tool', () => {
       options: {topN: 1, rankFields: ['title', 'body']},
     });
 
-    expect(mockPc.inference.rerank).toHaveBeenCalledWith(
-      'cohere-rerank-3.5',
-      'test query',
-      [{title: 'Doc 1', body: 'Content 1'}],
-      {topN: 1, rankFields: ['title', 'body']},
-    );
+    expect(mockPc.inference.rerank).toHaveBeenCalledWith({
+      model: 'cohere-rerank-3.5',
+      query: 'test query',
+      documents: [{title: 'Doc 1', body: 'Content 1'}],
+      topN: 1,
+      rankFields: ['title', 'body'],
+    });
   });
 
   it('returns error response on API failure', async () => {

--- a/src/tools/database/rerank-documents.ts
+++ b/src/tools/database/rerank-documents.ts
@@ -84,7 +84,7 @@ export function addRerankDocumentsTool(server: McpServer) {
     },
     async (args, pc) => {
       const {model, query, documents, options} = args as RerankArgs;
-      const results = await pc.inference.rerank(model, query, documents, options);
+      const results = await pc.inference.rerank({model, query, documents, ...options});
       return {
         content: [{type: 'text' as const, text: JSON.stringify(results, null, 2)}],
       };

--- a/src/tools/database/upsert-records.handler.test.ts
+++ b/src/tools/database/upsert-records.handler.test.ts
@@ -46,9 +46,9 @@ describe('upsert-records tool handler', () => {
 
     expect(mockPc.index).toHaveBeenCalledWith('test-index');
     expect(mockPc._mockIndex.namespace).toHaveBeenCalledWith('test-ns');
-    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith([
-      {id: '1', content: 'test content'},
-    ]);
+    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith({
+      records: [{id: '1', content: 'test content'}],
+    });
     expect(result).toEqual({
       content: [{type: 'text', text: expect.stringContaining('Upserted 1 record(s) successfully')}],
     });
@@ -82,9 +82,9 @@ describe('upsert-records tool handler', () => {
       records: [{_id: 'alt-1', content: 'test content'}],
     })) as {content: Array<{text: string}>};
 
-    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith([
-      {_id: 'alt-1', content: 'test content'},
-    ]);
+    expect(mockPc._mockIndex._mockNamespace.upsertRecords).toHaveBeenCalledWith({
+      records: [{_id: 'alt-1', content: 'test content'}],
+    });
     expect(result.content[0].text).toContain('successfully');
   });
 });

--- a/src/tools/database/upsert-records.ts
+++ b/src/tools/database/upsert-records.ts
@@ -71,7 +71,7 @@ export function addUpsertRecordsTool(server: McpServer) {
     async (args, pc) => {
       const {name, namespace, records} = args as UpsertArgs;
       const ns = pc.index(name).namespace(namespace);
-      await ns.upsertRecords(records);
+      await ns.upsertRecords({records});
       return {
         content: [
           {


### PR DESCRIPTION
## Summary
Dependabot #112 bumps `@pinecone-database/pinecone` to v8 but its **Build** step fails — v8 changed method signatures from positional args to a single options object. This recreates that bump **with the code fixes**.

## v8 API changes handled
| v6 | v8 |
|---|---|
| `ns.upsertRecords(records)` | `ns.upsertRecords({records})` |
| `inference.rerank(model, query, docs, opts)` | `inference.rerank({model, query, documents, ...opts})` |

Fixed call sites: `upsert-records.ts`, `rerank-documents.ts`, `cascading-search.ts` — plus the matching test assertions.

## Verification
- `npm run build`, `npm run lint`, `npm run format` (prettier check), **114/114 tests** pass
- Signatures confirmed against `@pinecone-database/pinecone@8.x` type definitions

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical signature updates to match SDK v8; behavior should match v6 if the SDK is backward-compatible at the HTTP layer. Runtime now requires Node 20+.
> 
> **Overview**
> Bumps `@pinecone-database/pinecone` from **6.1.4** to **8.2.0** (Node **>=20**). v8 replaces positional SDK calls with single options objects; this PR updates the MCP tools that were still on the old signatures.
> 
> **Upsert:** `upsertRecords(records)` → `upsertRecords({records})` in `upsert-records.ts`.
> 
> **Rerank:** `inference.rerank(model, query, documents, options)` → `inference.rerank({ model, query, documents, ...options })` in `rerank-documents.ts` and `cascading-search.ts`.
> 
> Test expectations are aligned with the new call shapes. Supersedes the Dependabot bump that failed without these fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c3bca7efddd031683c6ba78073dd72255ea737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->