### PR TITLE
chore: release prep — docs, security policy, schema guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Test with an AI tool or coding assistant:
         "/path/to/pinecone-mcp/dist/index.js"
       ],
       "env": {
-        "PINECONE_API_KEY": "<your-api-key>",
+        "PINECONE_API_KEY": "<your-api-key>"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This MCP server is focused on improving the experience of developers working wit
 
 To configure the MCP server to access your Pinecone project, you will need to generate an API key using the [console](https://app.pinecone.io). Without an API key, your AI tool will still be able to search documentation. However, it will not be able to manage or query your indexes.
 
-The MCP server requires [Node.js](https://nodejs.org) v18 or later. Ensure that `node` and `npx` are available in your `PATH`.
+The MCP server requires [Node.js](https://nodejs.org) v20 or later. Ensure that `node` and `npx` are available in your `PATH`.
 
 Next, you will need to configure your AI assistant to use the MCP server.
 
@@ -109,7 +109,7 @@ Pinecone Developer MCP Server provides the following tools for AI assistants to 
 - `search-docs`: Search the official Pinecone documentation.
 - `list-indexes`: Lists all Pinecone indexes.
 - `describe-index`: Describes the configuration of an index.
-- `describe-index-stats`: Provides statistics about the data in the index, including the  number of records and available namespaces.
+- `describe-index-stats`: Provides statistics about the data in the index, including the number of records and available namespaces.
 - `create-index-for-model`: Creates a new index that uses an integrated inference model to embed text as vectors.
 - `upsert-records`: Inserts or updates records in an index with integrated inference.
 - `search-records`: Searches for records in an index based on a text query, using integrated inference for embedding. Has options for metadata filtering and reranking.
@@ -124,7 +124,7 @@ Only indexes with integrated inference are supported. Assistants, indexes withou
 
 ### MCP server not appearing in your AI tool
 
-- Ensure Node.js v18 or later is installed: `node --version`
+- Ensure Node.js v20 or later is installed: `node --version`
 - Verify `npx` is available in your PATH: `which npx`
 - Check that your configuration file is in the correct location and has valid JSON syntax
 - Restart your AI tool after making configuration changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately to the Pinecone security team at
+**security@pinecone.io**, or via the ["Report a vulnerability"](https://github.com/pinecone-io/pinecone-mcp/security/advisories/new)
+button on this repository's Security tab.
+
+Include as much of the following as you can to help us triage quickly:
+
+- The affected version (`@pinecone-database/mcp`) and environment.
+- A description of the issue and its potential impact.
+- Steps to reproduce, or a proof of concept.
+
+We will acknowledge your report, keep you informed of our progress, and
+coordinate disclosure once a fix is available.
+
+## Supported versions
+
+Security fixes are released against the latest published version of
+`@pinecone-database/mcp`. Please upgrade to the latest release before
+reporting an issue.
+
+## Handling credentials
+
+This server authenticates to Pinecone using the `PINECONE_API_KEY`
+environment variable. Never commit API keys to source control or paste them
+into issues, pull requests, or logs. Rotate any key that may have been
+exposed via the [Pinecone console](https://app.pinecone.io).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "pinecone-mcp",
-  "version": "1.0.0",
+  "version": "0.2.1",
   "mcpServers": {
     "pinecone": {
       "command": "npx",

--- a/src/tools/database/create-index-for-model.ts
+++ b/src/tools/database/create-index-for-model.ts
@@ -16,7 +16,7 @@ type EmbedConfig = {
   fieldMap: {text: string};
 };
 
-const SCHEMA = {
+export const SCHEMA = {
   name: z.string().describe('A unique name to identify the new index.'),
   cloud: z
     .enum(['aws', 'gcp', 'azure'])

--- a/src/tools/database/describe-index-stats.ts
+++ b/src/tools/database/describe-index-stats.ts
@@ -7,7 +7,7 @@ const INSTRUCTIONS = `Describe the statistics of a Pinecone index, including
 record counts per namespace. Use this to discover which namespaces exist in an
 index. ${FRESHNESS_NOTE}`;
 
-const SCHEMA = {
+export const SCHEMA = {
   name: z.string().describe('The index to describe.'),
 };
 

--- a/src/tools/database/describe-index.ts
+++ b/src/tools/database/describe-index.ts
@@ -8,7 +8,7 @@ text to embed. Call this before upsert-records to learn the required field
 name. Check "status.ready" in the response to confirm the index can accept
 upserts and queries.`;
 
-const SCHEMA = {
+export const SCHEMA = {
   name: z.string().describe('The index to describe.'),
 };
 

--- a/src/tools/database/schema-composition.test.ts
+++ b/src/tools/database/schema-composition.test.ts
@@ -1,0 +1,46 @@
+import {describe, it, expect} from 'vitest';
+import {z} from 'zod';
+import {SCHEMA as CASCADING_SEARCH_SCHEMA} from './cascading-search.js';
+import {SCHEMA as CREATE_INDEX_SCHEMA} from './create-index-for-model.js';
+import {SCHEMA as DESCRIBE_INDEX_SCHEMA} from './describe-index.js';
+import {SCHEMA as DESCRIBE_INDEX_STATS_SCHEMA} from './describe-index-stats.js';
+import {SCHEMA as RERANK_DOCUMENTS_SCHEMA} from './rerank-documents.js';
+import {SCHEMA as SEARCH_RECORDS_SCHEMA} from './search-records.js';
+import {SCHEMA as UPSERT_RECORDS_SCHEMA} from './upsert-records.js';
+
+// Claude tool-use rejects JSON Schemas containing anyOf/oneOf/allOf composition
+// keywords (see #89, #92, #93). This guards every tool's input schema against
+// regressing, not just the one that originally broke.
+function findSchemaCompositionKeywords(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const keywords: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'anyOf' || key === 'oneOf' || key === 'allOf') {
+      keywords.push(key);
+    }
+    keywords.push(...findSchemaCompositionKeywords(nested));
+  }
+  return keywords;
+}
+
+const TOOL_SCHEMAS = {
+  'cascading-search': CASCADING_SEARCH_SCHEMA,
+  'create-index-for-model': CREATE_INDEX_SCHEMA,
+  'describe-index': DESCRIBE_INDEX_SCHEMA,
+  'describe-index-stats': DESCRIBE_INDEX_STATS_SCHEMA,
+  'rerank-documents': RERANK_DOCUMENTS_SCHEMA,
+  'search-records': SEARCH_RECORDS_SCHEMA,
+  'upsert-records': UPSERT_RECORDS_SCHEMA,
+};
+
+describe('tool input schemas are Claude-compatible', () => {
+  for (const [name, schema] of Object.entries(TOOL_SCHEMAS)) {
+    it(`${name} exports without schema composition keywords`, () => {
+      const jsonSchema = z.toJSONSchema(z.object(schema));
+      expect(findSchemaCompositionKeywords(jsonSchema)).toEqual([]);
+    });
+  }
+});

--- a/src/tools/database/search-records.ts
+++ b/src/tools/database/search-records.ts
@@ -31,7 +31,7 @@ const RERANK_SCHEMA = RERANK_OPTIONS_SCHEMA.optional().describe(
   "topN" results.`,
 );
 
-const SCHEMA = {
+export const SCHEMA = {
   name: z.string().describe('The index to search.'),
   namespace: z.string().describe('The namespace to search.'),
   query: SEARCH_QUERY_SCHEMA,

--- a/src/tools/database/upsert-records.ts
+++ b/src/tools/database/upsert-records.ts
@@ -46,7 +46,7 @@ const RECORD_SET_SCHEMA = z.array(RECORD_SCHEMA).describe(
   records in the index.`,
 );
 
-const SCHEMA = {
+export const SCHEMA = {
   name: z.string().describe('The index to upsert into.'),
   namespace: z.string().describe('The namespace to upsert into.'),
   records: RECORD_SET_SCHEMA,


### PR DESCRIPTION
Quick-win cleanups from the pre-release review. No runtime behavior change.

## Changes
- **Node version** — README said "v18 or later", `package.json` engines is `>=20`. Aligned README to v20.
- **gemini-extension.json** — version was `1.0.0` vs package `0.2.1`. Synced.
- **SECURITY.md** — added a vulnerability disclosure policy (was missing; enterprise reviews flag this).
- **Schema guards** — the Claude `anyOf/oneOf/allOf` guard (from #89/#92/#93) was tested only on `rerank-documents`. Generalized to **all** tool input schemas in `schema-composition.test.ts`; exported each tool's `SCHEMA` so it's testable. +7 tests.
- **Nits** — invalid trailing comma in CONTRIBUTING sample JSON; README double-space typo.

## Verification
- `npm run build`, `npm run lint`, `npm run format` (src/json), **121/121 tests** pass.

## Notes / follow-ups (not in this PR)
- `gemini-extension.json` version is still hand-synced — the release workflow bumps `package.json` but not this file. Consider sourcing it from a single place or adding a release step.
- Larger enterprise items remain roadmap: proxy/custom-endpoint config, leveled logging, CI Node matrix, configurable retries/timeouts, CHANGELOG, CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, metadata, and test-only schema exports with no changes to MCP tool runtime logic or API behavior.
> 
> **Overview**
> Pre-release housekeeping with **no runtime behavior changes**: documentation alignment, a new security disclosure policy, and broader tests for Claude-compatible tool JSON schemas.
> 
> **Docs and metadata:** README now requires **Node.js v20+** (matching `package.json` engines) and fixes a small typo in the `describe-index-stats` description. `gemini-extension.json` version is synced to **0.2.1**. CONTRIBUTING sample MCP JSON removes an invalid trailing comma in `env`.
> 
> **SECURITY.md** adds private vulnerability reporting (`security@pinecone.io` / GitHub Security advisories), supported-version policy, and guidance on `PINECONE_API_KEY` handling.
> 
> **Schema regression guard:** Several database tools now **export** their `SCHEMA` constants, and `schema-composition.test.ts` asserts that **all** listed tool input schemas produce JSON Schema **without** `anyOf` / `oneOf` / `allOf`—extending the fix from issues #89/#92/#93 beyond `rerank-documents` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f1dff75f257a41fe8a70e20df4a0e664670769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->