### PR TITLE
test: add live Pinecone integration smoke test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,31 @@
+name: Integration Tests
+
+# Live tests against a real Pinecone project. Not run on PRs — they need a
+# secret and create billable indexes. Run on a nightly schedule and on demand.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *' # 06:00 UTC daily
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/src/integration/database.integration.test.ts
+++ b/src/integration/database.integration.test.ts
@@ -1,0 +1,103 @@
+import {afterAll, describe, expect, it} from 'vitest';
+import {Pinecone} from '@pinecone-database/pinecone';
+import {createMockServer} from '../test-utils/mock-server.js';
+import {addCreateIndexForModelTool} from '../tools/database/create-index-for-model.js';
+import {addDescribeIndexStatsTool} from '../tools/database/describe-index-stats.js';
+import {addListIndexesTool} from '../tools/database/list-indexes.js';
+import {addSearchRecordsTool} from '../tools/database/search-records.js';
+import {addUpsertRecordsTool} from '../tools/database/upsert-records.js';
+
+// Live integration test. Exercises the real MCP tool handlers against a real
+// Pinecone project: create-index → upsert → search on a throwaway integrated
+// index, then delete it. This is the smoke test the mocked unit suite cannot
+// give us — it proves the Pinecone SDK actually accepts the calls the handlers
+// make (e.g. the v6→v8 signature changes).
+//
+// Skipped unless PINECONE_API_KEY is set, so normal CI (no key) is unaffected.
+// Run locally or in the dedicated integration workflow: `npm run test:integration`.
+const apiKey = process.env.PINECONE_API_KEY;
+
+// Unique, DNS-safe index name (lowercase alphanumerics + hyphens, <=45 chars).
+const INDEX_NAME = `mcp-it-${Math.floor(Date.now() / 1000).toString(36)}`;
+const NAMESPACE = 'integration';
+const TEXT_FIELD = 'chunk_text';
+
+const CREATE_TIMEOUT_MS = 300_000;
+const SEARCH_TIMEOUT_MS = 120_000;
+
+type ToolResult = {content: Array<{type: string; text: string}>; isError?: boolean};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe.skipIf(!apiKey)('database tools — live Pinecone integration', () => {
+  const server = createMockServer();
+  addCreateIndexForModelTool(server as never);
+  addUpsertRecordsTool(server as never);
+  addSearchRecordsTool(server as never);
+  addDescribeIndexStatsTool(server as never);
+  addListIndexesTool(server as never);
+
+  const call = async (name: string, args: Record<string, unknown>): Promise<ToolResult> => {
+    const tool = server.getRegisteredTool(name);
+    if (!tool) throw new Error(`tool ${name} not registered`);
+    const result = (await tool.handler(args)) as ToolResult;
+    if (result.isError) {
+      throw new Error(`tool ${name} failed: ${result.content.map((c) => c.text).join('\n')}`);
+    }
+    return result;
+  };
+
+  afterAll(async () => {
+    if (!apiKey) return;
+    // Best-effort cleanup so a failed assertion never leaks a paid index.
+    try {
+      await new Pinecone({apiKey}).deleteIndex(INDEX_NAME);
+    } catch {
+      // Index may not have been created; ignore.
+    }
+  }, 60_000);
+
+  it(
+    'creates an integrated index, upserts, and searches records',
+    async () => {
+      // 1. Create — handler blocks until the index is ready (waitUntilReady).
+      await call('create-index-for-model', {
+        name: INDEX_NAME,
+        cloud: 'aws',
+        region: 'us-east-1',
+        embed: {model: 'multilingual-e5-large', fieldMap: {text: TEXT_FIELD}},
+      });
+
+      // 2. Upsert a handful of records with distinct content.
+      const records = [
+        {_id: 'rec1', [TEXT_FIELD]: 'The Eiffel Tower is located in Paris, France.'},
+        {
+          _id: 'rec2',
+          [TEXT_FIELD]: 'Photosynthesis converts sunlight into chemical energy in plants.',
+        },
+        {_id: 'rec3', [TEXT_FIELD]: 'The mitochondrion is the powerhouse of the cell.'},
+      ];
+      await call('upsert-records', {name: INDEX_NAME, namespace: NAMESPACE, records});
+
+      // 3. Wait for the records to become searchable (indexing is async).
+      const deadline = Date.now() + SEARCH_TIMEOUT_MS;
+      let hits: Array<{_id: string}> = [];
+      while (Date.now() < deadline) {
+        const res = await call('search-records', {
+          name: INDEX_NAME,
+          namespace: NAMESPACE,
+          query: {topK: 3, inputs: {text: 'What landmark is in Paris?'}},
+        });
+        const parsed = JSON.parse(res.content[0].text);
+        hits = parsed?.result?.hits ?? [];
+        if (hits.length > 0) break;
+        await sleep(3_000);
+      }
+
+      // 4. The most relevant hit should be the Paris record.
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits[0]._id).toBe('rec1');
+    },
+    CREATE_TIMEOUT_MS,
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // Live integration tests run via `npm run test:integration`, not the default suite.
+    exclude: ['**/node_modules/**', '**/*.integration.test.ts'],
   },
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig} from 'vitest/config';
+
+// Live integration suite: hits a real Pinecone project. Requires PINECONE_API_KEY.
+// Kept separate from the default unit run so normal CI stays offline and fast.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.integration.test.ts'],
+    // Index create + embedding can take minutes; give the suite room.
+    testTimeout: 300_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Why
The current suite is **100% mocked**, so it can't catch Pinecone SDK contract breaks — e.g. the v6→v8 signature changes in #121 pass CI purely because the mocks were updated to match. This adds one real end-to-end smoke test.

## What
- **`src/integration/database.integration.test.ts`** — drives the real MCP tool handlers against a live Pinecone project: `create-index-for-model` → `upsert-records` → `search-records`, asserts the right record ranks first, then deletes the index (`afterAll`, best-effort).
- **Gated on `PINECONE_API_KEY`** via `describe.skipIf` — normal CI (no key) is unaffected. The file is excluded from `vitest.config.ts`, so `npm test` stays offline and fast (still 121 tests).
- **`npm run test:integration`** + `vitest.integration.config.ts` (long timeouts for index warm-up).
- **`.github/workflows/integration.yml`** — runs nightly (cron) + on manual dispatch, using the `PINECONE_API_KEY` repo secret.

## Not run on PRs — by design
Integration tests need a secret and create billable indexes, so they run **nightly / on-demand**, never on PRs. Verified locally: `npm test` = 121 pass (integration excluded); `npm run test:integration` with no key = skipped cleanly.

## Requires
A `PINECONE_API_KEY` repo secret for the scheduled/dispatch runs to actually execute (otherwise the suite skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test and CI configuration; no production MCP handler or SDK usage paths are modified.
> 
> **Overview**
> Adds a **live end-to-end smoke test** that runs real MCP database tool handlers against a Pinecone project (create integrated index → upsert → search → assert ranking), with **best-effort index deletion** in `afterAll`. The suite is **skipped when `PINECONE_API_KEY` is unset**, so default `npm test` stays mocked and fast.
> 
> **Test wiring:** `npm run test:integration` uses `vitest.integration.config.ts` (long timeouts); default `vitest.config.ts` **excludes** `*.integration.test.ts`.
> 
> **CI:** New `.github/workflows/integration.yml` runs integration tests on **daily cron** and **workflow_dispatch** only (not PRs), passing `PINECONE_API_KEY` from repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e96e8639fa186e7c4febeec0f39c77f22ddb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->