### PR TITLE
ci: add dependency audit + least-privilege permissions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -32,3 +35,6 @@ jobs:
 
       - name: Check formatting
         run: npx prettier --check 'src/**/*.ts' '*.json' '.prettierrc'
+
+      - name: Dependency audit (fail on high or critical)
+        run: npm audit --audit-level=high

--- a/package-lock.json
+++ b/package-lock.json
@@ -2739,9 +2739,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

Closes the two remaining gaps that keep `pinecone-mcp` from the top CI tier in our rubric. Existing CI already ran build, lint, tests, and format check on Node 24 — this PR adds:

1. **Least-privilege permissions** — a top-level `permissions: contents: read` block on the CI workflow.
2. **Dependency audit on PRs** — `npm audit --audit-level=high` now runs on every PR (previously audit ran only in `release.yml`, so PRs weren't gated).
3. **Remediates the one existing high advisory** — nanoid `GHSA-2v37-7h3g-55p8`, via a lockfile-only patch bump, so CI is green under the new gate.

## Verification (local, Node 24 / npm 11 — matches CI)

- `npm run build` ✅
- `npm run lint` (eslint) ✅
- `npm test` — **121 tests pass** ✅
- `npx prettier --check` ✅
- `npm audit --audit-level=high` → 0 vulnerabilities ✅
- Lockfile diff is balanced (3 insertions / 3 deletions) — a clean patch bump, no dependency churn.

## Why

Part of the fleet-wide effort to bring every public pinecone-io repo to a standard CI safety net. `pinecone-mcp` was the strongest repo already; this makes it exemplary and a good TypeScript template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and lockfile-only dependency patch changes with no application logic or runtime behavior changes.
> 
> **Overview**
> Tightens the **CI** workflow with **least-privilege** GitHub Actions permissions and a **dependency security gate** on every PR and push to `main`.
> 
> The workflow now sets top-level `permissions: contents: read` and runs `npm audit --audit-level=high` after the existing build, lint, test, and format steps—so high/critical advisories fail CI on PRs, not only at release time.
> 
> The lockfile bumps **nanoid** `3.3.17` → `3.3.18` so the new audit step passes under the existing high advisory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be237cc3b281f8be0e3a99c50f9ecda67f603ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->